### PR TITLE
Fix: allow help statements from classes that do not directly inherit …

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,3 +52,7 @@ Style/FileName:
 # Offense count: 1
 Style/ModuleFunction:
   Enabled: false
+
+# Offense count: 1
+Style/StringLiterals:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.3 (Next)
 
 * Your contribution here.
+* [#86](https://github.com/dblock/slack-ruby-bot/pull/86): Fix: allow help statements from classes that do not directly inherit from Base classes to appear in `bot help` - [@maclover7](https://github.com/maclover7).
 
 ### 0.8.2 (7/10/2016)
 

--- a/lib/slack-ruby-bot/support/commands_helper.rb
+++ b/lib/slack-ruby-bot/support/commands_helper.rb
@@ -66,11 +66,11 @@ module SlackRubyBot
     end
 
     def bot_help_attrs
-      commands_help_attrs.select { |k| k.class_name.constantize.superclass == SlackRubyBot::Bot }
+      commands_help_attrs.select { |k| k.class_name.constantize.ancestors.include?(SlackRubyBot::Bot) }
     end
 
     def other_commands_help_attrs
-      commands_help_attrs.select { |k| k.class_name.constantize.superclass == SlackRubyBot::Commands::Base }
+      commands_help_attrs.select { |k| k.class_name.constantize.ancestors.include?(SlackRubyBot::Commands::Base) }
     end
   end
 end

--- a/spec/slack-ruby-bot/support/commands_helper_spec.rb
+++ b/spec/slack-ruby-bot/support/commands_helper_spec.rb
@@ -81,14 +81,40 @@ describe SlackRubyBot::CommandsHelper do
     it 'do not show description for command without description' do
       expect(bot_desc).to include("*command_without_description*\n")
     end
+
+    class AnotherBotBase < SlackRubyBot::Bot
+    end
+
+    class AnotherBot < AnotherBotBase
+      help do
+        title 'Creating your own base class works too!'
+      end
+    end
+
+    it 'includes commands who do not directly inherit from the provided base class' do
+      expect(commands_helper.bot_desc_and_commands).to include("*Creating your own base class works too!*\n\n*Commands:*\n")
+    end
   end
 
   describe '#other_commands_descs' do
+    class AnotherCommandBase < SlackRubyBot::Commands::Base
+    end
+
+    class AnotherCommand < AnotherCommandBase
+      help do
+        title 'Creating your own base class works too!'
+      end
+    end
+
     let(:commands_desc) { commands_helper.other_commands_descs }
     let(:hello_command_desc) { commands_desc.find { |desc| desc =~ /\*hello\*/ } }
 
     it 'returns command name and description' do
       expect(hello_command_desc).to eq('*hello* - Says hello.')
+    end
+
+    it 'includes commands who do not directly inherit from provided base class' do
+      expect(commands_desc).to include('*Creating your own base class works too!*')
     end
   end
 


### PR DESCRIPTION
…from Base classes to appear in `bot help`