### PR TITLE
Fixed a couple of problems in TUTORIAL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.9.1 (Next)
 
+* [#98](https://github.com/slack-ruby/slack-ruby-bot/pull/98): Fixed a couple of problems in TUTORIAL.md - [@edruder](https://github.com/edruder).
 * [#95](https://github.com/slack-ruby/slack-ruby-bot/pull/95): Log team name and ID on successful connection - [@dblock](https://github.com/dblock).
 * [#94](https://github.com/slack-ruby/slack-ruby-bot/pull/94): Use the slack-ruby-danger gem - [@dblock](https://github.com/dblock).
 * [#86](https://github.com/dblock/slack-ruby-bot/pull/86): Fix: help statements from classes that do not directly inherit from `Base` appear in `bot help` - [@maclover7](https://github.com/maclover7).

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -19,6 +19,7 @@ gem 'slack-ruby-bot'
 gem 'puma'
 gem 'sinatra'
 gem 'dotenv'
+gem 'celluloid-io'
 
 group :development, :test do
   gem 'rake'
@@ -172,15 +173,18 @@ require 'slack-mathbot'
 
 #### Test the Bot Application
 
-Create a test for the bot application itself in `spec/slack-mathbot/app_spec.rb`.
+Create a test for the bot application itself in `spec/slack-mathbot/bot_spec.rb`.
 
 ```ruby
 require 'spec_helper'
 
-describe SlackMathbot::App do
+describe SlackMathbot::Bot do
   def app
     SlackMathbot::Bot.instance
   end
+
+  subject { app }
+
   it_behaves_like 'a slack ruby bot'
 end
 ```
@@ -196,6 +200,9 @@ describe SlackMathbot::Commands::Calculate do
   def app
     SlackMathbot::Bot.instance
   end
+
+  subject { app }
+
   it 'returns 4' do
     expect(message: "#{SlackRubyBot.config.user} calculate 2+2", channel: 'channel').to respond_with_slack_message('4')
   end


### PR DESCRIPTION
1. `foreman start` crashes unless the `celluloid-io` (or similar) gem is installed. (Maybe it should be brought in by `slack-ruby-bot`?)
1. Renamed the "app spec" to be a "bot spec", to match the source code.
1. The specs fail unless `subject` is defined.