### PR TITLE
[Fix #105] Allow bot to respond without explicit name in a message

### DIFF
--- a/lib/slack-ruby-bot/commands/base.rb
+++ b/lib/slack-ruby-bot/commands/base.rb
@@ -46,7 +46,7 @@ module SlackRubyBot
 
         def command(*values, &block)
           values = values.map { |value| Regexp.escape(value) }.join('|')
-          match Regexp.new("^(?<bot>[[:alnum:][:punct:]@<>]*)[\\s]+(?<command>#{values})([\\s]+(?<expression>.*)|)$", Regexp::IGNORECASE), &block
+          match Regexp.new("^((?<bot>[[:alnum:][:punct:]@<>]*)[\\s]+|)(?<command>#{values})([\\s]+(?<expression>.*)|)$", Regexp::IGNORECASE), &block
         end
 
         def invoke(client, data)
@@ -60,7 +60,7 @@ module SlackRubyBot
               match = route.match(expression)
               match ||= route.match(text) if text
               next unless match
-              next if match.names.include?('bot') && !client.name?(match['bot'])
+              next if match.names.include?('bot') && match['bot'] && !client.name?(match['bot'])
             when :scan
               match = expression.scan(route)
               next unless match.any?


### PR DESCRIPTION
Fix #105.
It is not 100% ready and has some rubocop offenses but I opened it just to show an idea.
