### PR TITLE
remove require for spec_helper

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.2 (Next)
 
 * Your contribution here.
+* [#120](https://github.com/slack-ruby/slack-ruby-bot/issues/120): Remove `require 'spec_helper'` from specs - [@accessd](https://github.com/accessd).
 
 ### 0.10.1 (2/12/2017)
 

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::App do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/client_spec.rb
+++ b/spec/slack-ruby-bot/client_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Client do
   describe '#send_gifs?' do
     context 'without giphy is false', unless: ENV.key?('WITH_GIPHY') do

--- a/spec/slack-ruby-bot/commands/about_spec.rb
+++ b/spec/slack-ruby-bot/commands/about_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands::Default do
   it 'lowercase' do
     expect(message: SlackRubyBot.config.user).to respond_with_slack_message(SlackRubyBot::ABOUT)

--- a/spec/slack-ruby-bot/commands/aliases_spec.rb
+++ b/spec/slack-ruby-bot/commands/aliases_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot do
   def client
     SlackRubyBot::Client.new aliases: %w(:emoji: alias каспаров)

--- a/spec/slack-ruby-bot/commands/bot_message_spec.rb
+++ b/spec/slack-ruby-bot/commands/bot_message_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands::Help do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/bot_spec.rb
+++ b/spec/slack-ruby-bot/commands/bot_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Bot do
   let! :command do
     Class.new(SlackRubyBot::Bot) do

--- a/spec/slack-ruby-bot/commands/commands_command_classes_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_command_classes_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands::Base do
   let! :command1 do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_precedence_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_precedence_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_regexp_escape_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_regexp_escape_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_spaces_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_spaces_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_with_block_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_with_block_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_with_expression_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_with_expression_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/direct_messages_spec.rb
+++ b/spec/slack-ruby-bot/commands/direct_messages_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/empty_text_spec.rb
+++ b/spec/slack-ruby-bot/commands/empty_text_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/help/attrs_spec.rb
+++ b/spec/slack-ruby-bot/commands/help/attrs_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands::Help::Attrs do
   let(:help_attrs) { described_class.new('WeatherBot') }
 

--- a/spec/slack-ruby-bot/commands/help_spec.rb
+++ b/spec/slack-ruby-bot/commands/help_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands::Help do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/hi_spec.rb
+++ b/spec/slack-ruby-bot/commands/hi_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands::Hi do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/match_spec.rb
+++ b/spec/slack-ruby-bot/commands/match_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/message_loop_spec.rb
+++ b/spec/slack-ruby-bot/commands/message_loop_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::App do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/nil_message_spec.rb
+++ b/spec/slack-ruby-bot/commands/nil_message_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/not_implemented_spec.rb
+++ b/spec/slack-ruby-bot/commands/not_implemented_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands::Base do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/operators_spec.rb
+++ b/spec/slack-ruby-bot/commands/operators_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/operators_with_block_spec.rb
+++ b/spec/slack-ruby-bot/commands/operators_with_block_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/scan_spec.rb
+++ b/spec/slack-ruby-bot/commands/scan_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/send_gif_spec.rb
+++ b/spec/slack-ruby-bot/commands/send_gif_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands, if: ENV.key?('WITH_GIPHY') do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/send_message_spec.rb
+++ b/spec/slack-ruby-bot/commands/send_message_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/send_message_with_gif_spec.rb
+++ b/spec/slack-ruby-bot/commands/send_message_with_gif_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands, if: ENV.key?('WITH_GIPHY') do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/unknown_spec.rb
+++ b/spec/slack-ruby-bot/commands/unknown_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Commands::Unknown do
   it 'invalid command' do
     expect(message: "#{SlackRubyBot.config.user} foobar").to respond_with_slack_message("Sorry <@user>, I don't understand that command!")

--- a/spec/slack-ruby-bot/config_spec.rb
+++ b/spec/slack-ruby-bot/config_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Config do
   describe '.send_gifs?' do
     after { ENV.delete 'SLACK_RUBY_BOT_SEND_GIFS' }

--- a/spec/slack-ruby-bot/hooks/hook_support_spec.rb
+++ b/spec/slack-ruby-bot/hooks/hook_support_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Hooks::HookSupport do
   subject do
     Class.new do

--- a/spec/slack-ruby-bot/hooks/message_spec.rb
+++ b/spec/slack-ruby-bot/hooks/message_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Hooks::Message do
   let(:message_hook) { described_class.new }
 

--- a/spec/slack-ruby-bot/hooks/set_spec.rb
+++ b/spec/slack-ruby-bot/hooks/set_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Hooks::Set do
   let(:client) { Slack::RealTime::Client.new }
 

--- a/spec/slack-ruby-bot/rspec/respond_with_error_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_error_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe RSpec do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/server_spec.rb
+++ b/spec/slack-ruby-bot/server_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Server do
   let(:logger) { subject.send :logger }
   let(:client) { Slack::RealTime::Client.new }

--- a/spec/slack-ruby-bot/support/commands_helper_spec.rb
+++ b/spec/slack-ruby-bot/support/commands_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::CommandsHelper do
   let(:bot_class) { Testing::WeatherBot }
   let(:command_class) { Testing::HelloCommand }

--- a/spec/slack-ruby-bot/support/loggable_spec.rb
+++ b/spec/slack-ruby-bot/support/loggable_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot::Loggable do
   let! :class_with_logger do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/version_spec.rb
+++ b/spec/slack-ruby-bot/version_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SlackRubyBot do
   it 'has a version' do
     expect(SlackRubyBot::VERSION).to_not be nil


### PR DESCRIPTION
Starting from RSpec 3 you can add `--require spec_helper` to your `.rspec` instead of at each spec.