### PR TITLE
Added Victorbot to the list of bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.10.2 (Next)
 
+* Your contribution here.
 * [#126](https://github.com/slack-ruby/slack-ruby-bot/pull/126): Added victorbot to the list of bots - [@emachnic](https://github.com/emachnic).
 
 ### 0.10.1 (2/12/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.10.2 (Next)
 
-* Your contribution here.
+* [#126](https://github.com/slack-ruby/slack-ruby-bot/pull/126): Added victorbot to the list of bots - [@emachnic](https://github.com/emachnic).
 
 ### 0.10.1 (2/12/2017)
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following examples of bots based on slack-ruby-bot are listed in growing ord
 * [slack-aws](https://github.com/dblock/slack-aws): Slack integration with Amazon Web Services.
 * [slack-deploy-bot](https://github.com/accessd/slack-deploy-bot): A Slack bot that helps you to deploy your apps.
 * [slack-gamebot](https://github.com/dblock/slack-gamebot): A game bot service for ping pong, chess, etc, hosted at [playplay.io](http://playplay.io).
+* [slack-victorbot](https://github.com/uShip/victorbot): A Slack bot to talk to the Victorops service.
 
 ### Commands and Operators
 


### PR DESCRIPTION
This just adds the Victorbot to the list of bots as discussed in the GitHub issue. I can rearrange if necessary