### PR TITLE
Added missing rspec dependencies to TUTORIAL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.10.2 (Next)
 
-* Your contribution here.
+* [#130](https://github.com/slack-ruby/slack-ruby-bot/issues/130): Added test dependencies in TUTORIAL.md [@jbristow](https://github.com/jbristow)
 
 ### 0.10.1 (2/12/2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.2 (Next)
 
-* [#130](https://github.com/slack-ruby/slack-ruby-bot/issues/130): Added test dependencies in TUTORIAL.md [@jbristow](https://github.com/jbristow)
+* Your contribution here.
+* [#130](https://github.com/slack-ruby/slack-ruby-bot/issues/130): Added test dependencies in TUTORIAL.md - [@jbristow](https://github.com/jbristow).
 
 ### 0.10.1 (2/12/2017)
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -29,6 +29,8 @@ end
 group :test do
   gem 'rspec'
   gem 'rack-test'
+  gem 'vcr'
+  gem 'webmock'
 end
 ```
 


### PR DESCRIPTION
I was trying to run the tutorial step-by-step and I ran into problems running rspec on Mac Sierra. Adding `vcr` and `webmock` explicitly solved the problem.