### PR TITLE
Add ability to receive multiple messages to test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.10.2 (Next)
 
-* Your contribution here.
+* [#136](https://github.com/slack-ruby/slack-ruby-bot/pull/136): Adds ability for tests to receive more than one message from client - [@aturkewi](https://github.com/aturkewi)
 * [#130](https://github.com/slack-ruby/slack-ruby-bot/issues/130): Added test dependencies in TUTORIAL.md - [@jbristow](https://github.com/jbristow).
 
 ### 0.10.1 (2/12/2017)

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
@@ -13,7 +13,7 @@ RSpec::Matchers.define :respond_with_slack_message do |expected|
 
     allow(Giphy).to receive(:random) if defined?(Giphy)
 
-    expect(client).to receive(:message).with(channel: channel, text: expected)
+    expect(client).to receive(:message).with(channel: channel, text: expected).at_least(:once)
     message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
     true
   end


### PR DESCRIPTION
Fixes issue #135 

Note: to run tests I had to add `gem 'faye-websocket'` to the `Gemfile`. Did not add this change because it seemed intentional to allow users to choose their web socket gem, but wanted to make sure to note it. 