### PR TITLE
initial attempt to hack in Cancancan support to Controllers

### DIFF
--- a/lib/slack-ruby-bot/mvc/controller/base.rb
+++ b/lib/slack-ruby-bot/mvc/controller/base.rb
@@ -2,7 +2,7 @@ module SlackRubyBot
   module MVC
     module Controller
       class Base
-        include ActiveSupport::Callbacks
+        include AbstractController::Callbacks
 
         class << self
           attr_reader :abstract

--- a/lib/slack-ruby-bot/mvc/controller/callbacks.rb
+++ b/lib/slack-ruby-bot/mvc/controller/callbacks.rb
@@ -1,0 +1,216 @@
+module SlackRubyBot
+  module MVC
+    module Controller
+      module AbstractController
+        # = Abstract Controller Callbacks
+        #
+        # Abstract Controller provides hooks during the life cycle of a controller action.
+        # Callbacks allow you to trigger logic during this cycle. Available callbacks are:
+        #
+        # * <tt>after_action</tt>
+        # * <tt>append_after_action</tt>
+        # * <tt>append_around_action</tt>
+        # * <tt>append_before_action</tt>
+        # * <tt>around_action</tt>
+        # * <tt>before_action</tt>
+        # * <tt>prepend_after_action</tt>
+        # * <tt>prepend_around_action</tt>
+        # * <tt>prepend_before_action</tt>
+        # * <tt>skip_after_action</tt>
+        # * <tt>skip_around_action</tt>
+        # * <tt>skip_before_action</tt>
+        #
+        # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
+        #
+        module Callbacks
+          extend ActiveSupport::Concern
+
+          # Uses ActiveSupport::Callbacks as the base functionality. For
+          # more details on the whole callback system, read the documentation
+          # for ActiveSupport::Callbacks.
+          include ActiveSupport::Callbacks
+
+          included do
+            define_callbacks :process_action,
+                             terminator: ->(controller, result_lambda) { result_lambda.call if result_lambda.is_a?(Proc); controller.performed? },
+                             skip_after_callbacks_if_terminated: true
+          end
+
+          # Override AbstractController::Base's process_action to run the
+          # process_action callbacks around the normal behavior.
+          def process_action(*args)
+            run_callbacks(:process_action) do
+              super
+            end
+          end
+
+          module ClassMethods
+            # If +:only+ or +:except+ are used, convert the options into the
+            # +:if+ and +:unless+ options of ActiveSupport::Callbacks.
+            #
+            # The basic idea is that <tt>:only => :index</tt> gets converted to
+            # <tt>:if => proc {|c| c.action_name == "index" }</tt>.
+            #
+            # Note that <tt>:only</tt> has priority over <tt>:if</tt> in case they
+            # are used together.
+            #
+            #   only: :index, if: -> { true } # the :if option will be ignored.
+            #
+            # Note that <tt>:if</tt> has priority over <tt>:except</tt> in case they
+            # are used together.
+            #
+            #   except: :index, if: -> { true } # the :except option will be ignored.
+            #
+            # ==== Options
+            # * <tt>only</tt>   - The callback should be run only for this action.
+            # * <tt>except</tt>  - The callback should be run for all actions except this action.
+            def _normalize_callback_options(options)
+              _normalize_callback_option(options, :only, :if)
+              _normalize_callback_option(options, :except, :unless)
+            end
+
+            def _normalize_callback_option(options, from, to) # :nodoc:
+              if from = options[from]
+                _from = Array(from).map(&:to_s).to_set
+                from = proc { |c| _from.include? c.action_name }
+                options[to] = Array(options[to]).unshift(from)
+              end
+            end
+
+            # Take callback names and an optional callback proc, normalize them,
+            # then call the block with each callback. This allows us to abstract
+            # the normalization across several methods that use it.
+            #
+            # ==== Parameters
+            # * <tt>callbacks</tt> - An array of callbacks, with an optional
+            #   options hash as the last parameter.
+            # * <tt>block</tt>    - A proc that should be added to the callbacks.
+            #
+            # ==== Block Parameters
+            # * <tt>name</tt>     - The callback to be added.
+            # * <tt>options</tt>  - A hash of options to be used when adding the callback.
+            def _insert_callbacks(callbacks, block = nil)
+              options = callbacks.extract_options!
+              _normalize_callback_options(options)
+              callbacks.push(block) if block
+              callbacks.each do |callback|
+                yield callback, options
+              end
+            end
+
+            ##
+            # :method: before_action
+            #
+            # :call-seq: before_action(names, block)
+            #
+            # Append a callback before actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: prepend_before_action
+            #
+            # :call-seq: prepend_before_action(names, block)
+            #
+            # Prepend a callback before actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: skip_before_action
+            #
+            # :call-seq: skip_before_action(names)
+            #
+            # Skip a callback before actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: append_before_action
+            #
+            # :call-seq: append_before_action(names, block)
+            #
+            # Append a callback before actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: after_action
+            #
+            # :call-seq: after_action(names, block)
+            #
+            # Append a callback after actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: prepend_after_action
+            #
+            # :call-seq: prepend_after_action(names, block)
+            #
+            # Prepend a callback after actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: skip_after_action
+            #
+            # :call-seq: skip_after_action(names)
+            #
+            # Skip a callback after actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: append_after_action
+            #
+            # :call-seq: append_after_action(names, block)
+            #
+            # Append a callback after actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: around_action
+            #
+            # :call-seq: around_action(names, block)
+            #
+            # Append a callback around actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: prepend_around_action
+            #
+            # :call-seq: prepend_around_action(names, block)
+            #
+            # Prepend a callback around actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: skip_around_action
+            #
+            # :call-seq: skip_around_action(names)
+            #
+            # Skip a callback around actions. See _insert_callbacks for parameter details.
+
+            ##
+            # :method: append_around_action
+            #
+            # :call-seq: append_around_action(names, block)
+            #
+            # Append a callback around actions. See _insert_callbacks for parameter details.
+
+            # set up before_action, prepend_before_action, skip_before_action, etc.
+            # for each of before, after, and around.
+            [:before, :after, :around].each do |callback|
+              define_method "#{callback}_action" do |*names, &blk|
+                _insert_callbacks(names, blk) do |name, options|
+                  set_callback(:process_action, callback, name, options)
+                end
+              end
+
+              define_method "prepend_#{callback}_action" do |*names, &blk|
+                _insert_callbacks(names, blk) do |name, options|
+                  set_callback(:process_action, callback, name, options.merge(prepend: true))
+                end
+              end
+
+              # Skip a before, after or around callback. See _insert_callbacks
+              # for details on the allowed parameters.
+              define_method "skip_#{callback}_action" do |*names|
+                _insert_callbacks(names) do |name, options|
+                  skip_callback(:process_action, callback, name, options)
+                end
+              end
+
+              # *_action is the same as append_*_action
+              alias_method :"append_#{callback}_action", :"#{callback}_action"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/slack-ruby-bot/mvc/mvc.rb
+++ b/lib/slack-ruby-bot/mvc/mvc.rb
@@ -1,5 +1,8 @@
+require_relative '../mvc/controller/callbacks'
 require_relative '../mvc/controller/base'
 
 require_relative '../mvc/model/base'
 
 require_relative '../mvc/view/base'
+
+require 'active_support/core_ext/string/inflections'

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/invoke_command.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/invoke_command.rb
@@ -1,0 +1,104 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :invoke_command do |expected|
+  match do |actual|
+    client = if respond_to?(:client)
+               send(:client)
+             else
+               SlackRubyBot::Client.new
+             end
+
+    message_command = SlackRubyBot::Hooks::Message.new
+    channel, user, message = parse(actual)
+
+    expect(client).to receive(:message).with(channel: channel, text: expected)
+    message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
+    true
+  end
+
+  private
+
+  def parse(actual)
+    unless actual.is_a?(Hash)
+      actual = { message: actual }
+      channel = 'channel'
+      user = parse_user(actual)
+    end
+    [actual[:channel] || channel, actual[:user] || user || parse_user(actual[:message]) || 'WRONG', actual[:message]]
+  end
+
+  def parse_user(actual)
+    actual.split(' ').first
+  end
+end
+
+RSpec::Matchers.define :not_invoke_command do |expected|
+  match do |actual|
+    client = if respond_to?(:client)
+               send(:client)
+             else
+               SlackRubyBot::Client.new
+             end
+
+    message_command = SlackRubyBot::Hooks::Message.new
+    channel, user, message = parse(actual)
+
+    expect(client).not_to receive(:message).with(channel: channel, text: expected)
+    message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
+    true
+  end
+
+  private
+
+  def parse(actual)
+    unless actual.is_a?(Hash)
+      actual = { message: actual }
+      channel = 'channel'
+      user = parse_user(actual)
+    end
+    [actual[:channel] || channel, actual[:user] || user || parse_user(actual[:message]) || 'WRONG', actual[:message]]
+  end
+
+  def parse_user(actual)
+    actual.split(' ').first
+  end
+end
+
+RSpec::Matchers.define :raise_from_command do |error, error_message|
+  match do |actual|
+    client = if respond_to?(:client)
+               send(:client)
+             else
+               SlackRubyBot::Client.new
+             end
+
+    message_command = SlackRubyBot::Hooks::Message.new
+    channel, user, message = parse(actual)
+
+    begin
+      expect do
+        message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
+      end.to raise_error error, error_message
+    rescue RSpec::Expectations::ExpectationNotMetError => e
+      STDERR.puts "In rescue, got e [#{e.inspect}]"
+      @error_message = e.message
+      raise e
+    end
+    true
+  end
+
+  private
+
+  def parse(actual)
+    unless actual.is_a?(Hash)
+      actual = { message: actual }
+      channel = 'channel'
+      user = parse_user(actual)
+    end
+    [actual[:channel] || channel, actual[:user] || user || parse_user(actual[:message]) || 'WRONG', actual[:message]]
+  end
+
+  def parse_user(actual)
+    actual.split(' ').first
+  end
+end

--- a/spec/slack-ruby-bot/mvc/controller/controller_cancancan_spec.rb
+++ b/spec/slack-ruby-bot/mvc/controller/controller_cancancan_spec.rb
@@ -1,0 +1,79 @@
+require 'cancancan'
+
+class User
+  ROLES = { 0 => :guest, 1 => :user, 2 => :moderator, 3 => :admin }.freeze
+
+  attr_reader :role
+
+  def initialize(role_id = 0)
+    @role = ROLES.key?(role_id.to_i) ? ROLES[role_id.to_i] : ROLES[0]
+  end
+
+  def role?(role_name)
+    role == role_name
+  end
+end
+
+class Ability
+  include CanCan::Ability
+end
+
+describe SlackRubyBot::MVC::Controller::Base, 'execution with guest role' do
+  let(:controller) do
+    Class.new(SlackRubyBot::MVC::Controller::Base) do
+      include CanCan::ControllerAdditions
+      authorize_resource # doesn't work; assumes this is an +ActionController+ subclass for its meta-magic to work
+      attr_accessor :__flag
+      def quxo
+        authorize! :quxo, self
+        @__flag = true
+        client.say(channel: data.channel, text: "#{match[:command]}: #{match[:expression]}")
+      end
+
+      def current_user
+        @user ||= User.new(0)
+      end
+
+      def current_ability
+        @current_ability = ::Ability.new(current_user)
+      end
+
+      class << self
+        def name
+          # anonymous classes don't have a name, but Cancancan relies on one
+          'SpecController'
+        end
+      end
+    end
+  end
+
+  after(:each) { controller.reset! }
+
+  it 'denies access to run the controller method when no Ability is set' do
+    Ability.class_eval do
+      def initialize(user) end
+    end
+    model = SlackRubyBot::MVC::Model::Base.new
+    view = SlackRubyBot::MVC::View::Base.new
+    instance = controller.new(model, view)
+    instance.current_ability
+    instance.__flag = false
+    expect(message: "  #{SlackRubyBot.config.user}   quxo red").to raise_from_command(CanCan::AccessDenied, 'You are not authorized to access this page.')
+    expect(instance.__flag).to be false
+  end
+
+  it 'allows access to run the controller method when an Ability is set' do
+    Ability.class_eval do
+      def initialize(_user)
+        can :quxo, :all
+      end
+    end
+    model = SlackRubyBot::MVC::Model::Base.new
+    view = SlackRubyBot::MVC::View::Base.new
+    instance = controller.new(model, view)
+    instance.current_ability
+    instance.__flag = false
+    expect(message: "  #{SlackRubyBot.config.user}   quxo red").to invoke_command('quxo: red')
+    expect(instance.__flag).to be_truthy
+  end
+end


### PR DESCRIPTION
The `cancancan` gem relies upon lots of ActionController, ActiveSupport, ActiveModel, and ActiveRecord internals to do its job. To get *basic* permissions working I had to pull in a lot more code from ActionController. Even with this additional code the `before_action` hooks did not setup correctly for the controller actions. To fix this, a direct call to `authorize :method_name, self` is required in each method right now.

Ultimately I think we could get this to work but it would be a lot of work.

Plus, these permissions/abilities would only work with Controller actions. They would never work with the existing `command` structure.

@digitalextremist Wanted you to see this too.

While integrating this gem is feasible I do not think it is practical. 

Can we use this PR to discuss alternate approaches? My `acl` branch already works... :)