### PR TITLE
Handle commands with spaces when using Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.3 (date)
 
 * Your contribution here.
+* [#144](https://github.com/slack-ruby/slack-ruby-bot/pull/144): Support usage of commands with embedded spaces when using Controller methods - [@chuckremes](https://github.com/chuckremes).
 
 ### 0.10.2 (06/03/2017)
 

--- a/spec/slack-ruby-bot/mvc/controller/controller_to_command_spec.rb
+++ b/spec/slack-ruby-bot/mvc/controller/controller_to_command_spec.rb
@@ -95,3 +95,29 @@ describe SlackRubyBot::MVC::Controller::Base, 'execution' do
     expect(instance.__flag).to be_truthy
   end
 end
+
+describe SlackRubyBot::MVC::Controller::Base, 'command text conversion' do
+  let(:controller) do
+    Class.new(SlackRubyBot::MVC::Controller::Base) do
+      def quxo_foo_bar
+        client.say(channel: data.channel, text: "#{match[:command].downcase}: #{match[:expression]}")
+      end
+    end
+  end
+
+  after(:each) { controller.reset! }
+
+  it 'converts a command with spaces into a controller method with underscores separating the tokens' do
+    model = SlackRubyBot::MVC::Model::Base.new
+    view = SlackRubyBot::MVC::View::Base.new
+    controller.new(model, view)
+    expect(message: "  #{SlackRubyBot.config.user}   quxo foo bar red").to respond_with_slack_message('quxo foo bar: red')
+  end
+
+  it 'converts a command with upper case letters into a lower case method call' do
+    model = SlackRubyBot::MVC::Model::Base.new
+    view = SlackRubyBot::MVC::View::Base.new
+    controller.new(model, view)
+    expect(message: "  #{SlackRubyBot.config.user}   Quxo Foo Bar red").to respond_with_slack_message('quxo foo bar: red')
+  end
+end


### PR DESCRIPTION
I missed a use-case when first designing the MVC classes. Sometimes people design commands like this:

```ruby
class Agent < SlackRubyBot::Bot
  command 'run some command' do |*args|
    ...
  end
end
```

If someone sent a command with spaces to the controller it would fail to match any known method.

So, the Controller class was augmented to support this. Any method names that contain embedded underscores '_' will now generate a command matcher with spaces. When that command matches a route and we try to call the corresponding controller method, the command is downcased and converted to a `method_name_with_spaces`.