### PR TITLE
Improve MVC::Controller to allow method "aliasing"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.3 (date)
 
 * Your contribution here.
+* [#145](https://github.com/slack-ruby/slack-ruby-bot/pull/145): Map multiple command strings to same controller method - [@chuckremes](https://github.com/chuckremes).
 * [#144](https://github.com/slack-ruby/slack-ruby-bot/pull/144): Support usage of commands with embedded spaces when using Controller methods - [@chuckremes](https://github.com/chuckremes).
 
 ### 0.10.2 (06/03/2017)

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Consider the following `Agent` class which is the simplest default approach to t
 
 ```ruby
 class Agent < SlackRubyBot::Bot
-  command 'sayhello' do |client, data, match|
+  command 'sayhello', 'alternate way to call hello' do |client, data, match|
     client.say(channel: data.channel, text: "Received command #{match[:command]} with args #{match[:expression]}")
   end
 end
@@ -375,6 +375,7 @@ class MyController < SlackRubyBot::MVC::Controller::Base
   def sayhello
     client.say(channel: data.channel, text: "Received command #{match[:command]} with args #{match[:expression]}")
   end
+  alternate_name :sayhello, :alternate_way_to_call_hello
 end
 MyController.new(MyModel.new, MyView.new)
 ```
@@ -383,6 +384,8 @@ Note in the above example that the Controller instance method `sayhello` does no
 However, the Controller anticipates that the model and view objects should contain business logic that will also operate on the `client`, `data`, and `match` objects. The controller provides access to the model and view via the `model` and `view` accessor methods. The [inventory example](examples/inventory/inventorybot.rb) provides a full example of a Model, View, and Controller working together.
 
 A Controller may need helper methods for certain work. To prevent the helper method from creating a route that the bot will respond to directly, the instance method name should begin with an underscore (e.g. `_my_helper_method`). When building the bot routes, these methods will be skipped.
+
+Calling `alternate_name` after the method definition allows for method aliases similar to the regular `command` structure. When commands can be triggered by multiple text strings it's useful to have that ability map to the controller methods too.
 
 Lastly, the Controller class includes `ActiveSupport::Callbacks` which allows for full flexibility in creating `before`, `after`, and `around` hooks for all methods. Again, see the [inventory example](examples/inventory/inventorybot.rb) for more information.
 

--- a/lib/slack-ruby-bot/mvc/controller/base.rb
+++ b/lib/slack-ruby-bot/mvc/controller/base.rb
@@ -16,6 +16,10 @@ module SlackRubyBot
             Base.instance_variable_get(:@command_class)
           end
 
+          def aliases
+            Base.instance_variable_get(:@aliases)
+          end
+
           def reset!
             # Remove any earlier anonymous classes from prior calls so we don't leak them
             Commands::Base.command_classes.delete(Controller::Base.command_class) if Base.command_class
@@ -43,6 +47,7 @@ module SlackRubyBot
           def register_controller(controller)
             # Only used to keep a reference around so the instance object doesn't get garbage collected
             Base.instance_variable_set(:@controllers, []) unless controllers
+            Base.instance_variable_set(:@aliases, Hash.new { |h, k| h[k] = [] }) unless aliases
             controller_ary = Base.instance_variable_get(:@controllers)
             controller_ary << controller
             klass = controller.class
@@ -53,15 +58,18 @@ module SlackRubyBot
                        # Be sure to include shadowed public instance methods of this class
                        klass.public_instance_methods(false)).uniq.map(&:to_s)
 
-            methods.each do |meth_name|
-              next if meth_name[0] == '_'
-              method_name = convert_method_name(meth_name)
+            methods.each do |name|
+              next if name[0] == '_'
+              commands = lookup_command_name(name)
 
-              # sprinkle a little syntactic sugar on top of existing `command` infrastructure
-              command_class.class_eval do
-                command method_name do |client, data, match|
-                  controller.use_args(client, data, match)
-                  controller.call_command
+              # Generates a command for each controller method *and* its aliases
+              commands.each do |command_string|
+                # sprinkle a little syntactic sugar on top of existing `command` infrastructure
+                command_class.class_eval do
+                  command command_string do |client, data, match|
+                    controller.use_args(client, data, match)
+                    controller.call_command
+                  end
                 end
               end
             end
@@ -78,10 +86,41 @@ module SlackRubyBot
             controller.public_instance_methods(true)
           end
 
+          # Maps a controller method name to an alternate command name. Used in cases where
+          # a command can be called via multiple text strings.
+          #
+          # Call this method *after* defining the original method.
+          #
+          #  Class.new(SlackRubyBot::MVC::Controller::Base) do
+          #    def quxo_foo_bar
+          #      client.say(channel: data.channel, text: "quxo foo bar: #{match[:expression]}")
+          #    end
+          #    # setup alias name after original method definition
+          #    alternate_name :quxo_foo_bar, :another_text_string
+          #  end
+          #
+          # This is equivalent to:
+          #
+          # e.g.
+          #  command 'quxo foo bar', 'another text string' do |*args|
+          #    ..
+          #  end
+          def alternate_name(original_name, alias_name)
+            command_name = convert_method_name_to_command_string(original_name)
+            command_alias = convert_method_name_to_command_string(alias_name)
+            aliases[command_name] << command_alias
+            alias_method(alias_name, original_name)
+          end
+
           private
 
-          def convert_method_name(name)
-            name.tr('_', ' ')
+          def lookup_command_name(name)
+            name = convert_method_name_to_command_string(name)
+            [name] + aliases[name]
+          end
+
+          def convert_method_name_to_command_string(name)
+            name.to_s.tr('_', ' ')
           end
         end
 

--- a/lib/slack-ruby-bot/mvc/controller/base.rb
+++ b/lib/slack-ruby-bot/mvc/controller/base.rb
@@ -105,11 +105,15 @@ module SlackRubyBot
           #  command 'quxo foo bar', 'another text string' do |*args|
           #    ..
           #  end
-          def alternate_name(original_name, alias_name)
+          def alternate_name(original_name, *alias_names)
             command_name = convert_method_name_to_command_string(original_name)
-            command_alias = convert_method_name_to_command_string(alias_name)
-            aliases[command_name] << command_alias
-            alias_method(alias_name, original_name)
+            command_aliases = alias_names.map do |name|
+              convert_method_name_to_command_string(name)
+            end
+
+            aliases[command_name] += command_aliases
+
+            alias_names.each { |alias_name| alias_method(alias_name, original_name) }
           end
 
           private

--- a/spec/slack-ruby-bot/mvc/controller/controller_to_command_spec.rb
+++ b/spec/slack-ruby-bot/mvc/controller/controller_to_command_spec.rb
@@ -121,3 +121,23 @@ describe SlackRubyBot::MVC::Controller::Base, 'command text conversion' do
     expect(message: "  #{SlackRubyBot.config.user}   Quxo Foo Bar red").to respond_with_slack_message('quxo foo bar: red')
   end
 end
+
+describe SlackRubyBot::MVC::Controller::Base, 'alternate command text conversion' do
+  let(:controller) do
+    Class.new(SlackRubyBot::MVC::Controller::Base) do
+      def quxo_foo_bar
+        client.say(channel: data.channel, text: "quxo foo bar: #{match[:expression]}")
+      end
+      alternate_name :quxo_foo_bar, :another_text_string
+    end
+  end
+
+  after(:each) { controller.reset! }
+
+  it 'aliases another valid command string to the controller method' do
+    model = SlackRubyBot::MVC::Model::Base.new
+    view = SlackRubyBot::MVC::View::Base.new
+    controller.new(model, view)
+    expect(message: "  #{SlackRubyBot.config.user}   another text string red").to respond_with_slack_message('quxo foo bar: red')
+  end
+end

--- a/spec/slack-ruby-bot/mvc/controller/controller_to_command_spec.rb
+++ b/spec/slack-ruby-bot/mvc/controller/controller_to_command_spec.rb
@@ -128,7 +128,7 @@ describe SlackRubyBot::MVC::Controller::Base, 'alternate command text conversion
       def quxo_foo_bar
         client.say(channel: data.channel, text: "quxo foo bar: #{match[:expression]}")
       end
-      alternate_name :quxo_foo_bar, :another_text_string
+      alternate_name :quxo_foo_bar, :another_text_string, :third_text_string
     end
   end
 
@@ -139,5 +139,12 @@ describe SlackRubyBot::MVC::Controller::Base, 'alternate command text conversion
     view = SlackRubyBot::MVC::View::Base.new
     controller.new(model, view)
     expect(message: "  #{SlackRubyBot.config.user}   another text string red").to respond_with_slack_message('quxo foo bar: red')
+  end
+
+  it 'allows for aliasing multiple names in a single call' do
+    model = SlackRubyBot::MVC::Model::Base.new
+    view = SlackRubyBot::MVC::View::Base.new
+    controller.new(model, view)
+    expect(message: "  #{SlackRubyBot.config.user}   third text string red").to respond_with_slack_message('quxo foo bar: red')
   end
 end


### PR DESCRIPTION
Without controllers we can define commands that match multiple strings.

e.g.
```ruby
command 'say hello', 'sayhello', 'hi', 'sayhi' do |*args|
  ...
end
```

This PR allows for controllers to support the same kind of multiple matching.

```ruby
class MyController < Controller
  def say_hello
    # do whatever...
  end
  alternate_name :say_hello, :sayhello
  alternate_name :say_hello, :hi
  alternate_name :say_hello, :sayhi
end
```

I think this PR brings feature parity now between regular `command`s and Controller commands.