### PR TITLE
Add 'mute' configuration option

### DIFF
--- a/lib/slack-ruby-bot/bot.rb
+++ b/lib/slack-ruby-bot/bot.rb
@@ -11,6 +11,7 @@ module SlackRubyBot
     end
 
     def self.call(client, data, _match)
+      return if SlackRubyBot::Config.mute
       client.say(channel: data.channel, text: "Sorry <@#{data.user}>, I don't understand that command!", gif: 'understand')
     end
   end

--- a/lib/slack-ruby-bot/commands/about.rb
+++ b/lib/slack-ruby-bot/commands/about.rb
@@ -5,6 +5,7 @@ module SlackRubyBot
       match(/^(?<bot>[[:alnum:][:punct:]@<>]*)$/u)
 
       def self.call(client, data, _match)
+        return if SlackRubyBot::Config.mute
         client.say(channel: data.channel, text: SlackRubyBot::ABOUT, gif: 'selfie')
       end
     end

--- a/lib/slack-ruby-bot/commands/help.rb
+++ b/lib/slack-ruby-bot/commands/help.rb
@@ -15,7 +15,7 @@ module SlackRubyBot
                  general_text
                end
 
-        client.say(channel: data.channel, text: text, gif: 'help')
+        client.say(channel: data.channel, text: text, gif: 'help') unless SlackRubyBot::Config.mute
       end
 
       class << self

--- a/lib/slack-ruby-bot/commands/hi.rb
+++ b/lib/slack-ruby-bot/commands/hi.rb
@@ -7,6 +7,7 @@ module SlackRubyBot
       end
 
       def self.call(client, data, _match)
+        return if SlackRubyBot::Config.mute
         client.say(channel: data.channel, text: "Hi <@#{data.user}>!", gif: 'hi')
       end
     end

--- a/lib/slack-ruby-bot/commands/unknown.rb
+++ b/lib/slack-ruby-bot/commands/unknown.rb
@@ -4,6 +4,7 @@ module SlackRubyBot
       match(/^(?<bot>\S*)[\s]*(?<expression>.*)$/)
 
       def self.call(client, data, _match)
+        return if SlackRubyBot::Config.mute
         client.say(channel: data.channel, text: "Sorry <@#{data.user}>, I don't understand that command!", gif: 'understand')
       end
     end

--- a/lib/slack-ruby-bot/config.rb
+++ b/lib/slack-ruby-bot/config.rb
@@ -2,7 +2,7 @@ module SlackRubyBot
   module Config
     extend self
 
-    ATTRS = [:token, :url, :aliases, :user, :user_id, :team, :team_id, :allow_message_loops, :send_gifs].freeze
+    ATTRS = [:token, :url, :aliases, :user, :user_id, :team, :team_id, :allow_message_loops, :send_gifs, :mute].freeze
     attr_accessor(*ATTRS)
 
     def allow_message_loops?

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/not_respond.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/not_respond.rb
@@ -1,0 +1,25 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :not_respond do |expected|
+  match do |actual|
+    client = if respond_to?(:client)
+               send(:client)
+             else
+               SlackRubyBot::Client.new
+             end
+
+    message_command = SlackRubyBot::Hooks::Message.new
+    channel, user, message = parse(actual)
+
+    expect(client).not_to receive(:message)
+    message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
+    true
+  end
+
+  private
+
+  def parse(actual)
+    actual = { message: actual } unless actual.is_a?(Hash)
+    [actual[:channel] || 'channel', actual[:user] || 'user', actual[:message]]
+  end
+end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/not_respond.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/not_respond.rb
@@ -1,6 +1,6 @@
 require 'rspec/expectations'
 
-RSpec::Matchers.define :not_respond do |expected|
+RSpec::Matchers.define :not_respond do
   match do |actual|
     client = if respond_to?(:client)
                send(:client)

--- a/spec/slack-ruby-bot/commands/about_spec.rb
+++ b/spec/slack-ruby-bot/commands/about_spec.rb
@@ -11,4 +11,9 @@ describe SlackRubyBot::Commands::Default do
   it 'id' do
     expect(message: "<@#{SlackRubyBot.config.user_id}>").to respond_with_slack_message(SlackRubyBot::ABOUT)
   end
+  it 'does not respond when mute' do
+    SlackRubyBot::Config.mute = true
+    expect(message: SlackRubyBot.config.user).to not_respond
+    SlackRubyBot::Config.mute = true
+  end
 end

--- a/spec/slack-ruby-bot/commands/bot_message_spec.rb
+++ b/spec/slack-ruby-bot/commands/bot_message_spec.rb
@@ -5,4 +5,10 @@ describe SlackRubyBot::Commands::Help do
   it 'bot' do
     expect(message: "#{SlackRubyBot.config.user} bot").to respond_with_slack_message("Sorry <@user>, I don't understand that command!")
   end
+
+  it 'bot does not respond when mute' do
+    SlackRubyBot::Config.mute = true
+    expect(message: "#{SlackRubyBot.config.user} bot").to not_respond
+    SlackRubyBot::Config.mute = false
+  end
 end

--- a/spec/slack-ruby-bot/commands/help_spec.rb
+++ b/spec/slack-ruby-bot/commands/help_spec.rb
@@ -23,4 +23,10 @@ MSG
 
     expect(message: "#{SlackRubyBot.config.user} help").to respond_with_slack_message(message)
   end
+
+  it 'does not respond when mute' do
+    SlackRubyBot::Config.mute = true
+    expect(message: "#{SlackRubyBot.config.user} help").to not_respond
+    SlackRubyBot::Config.mute = false
+  end
 end

--- a/spec/slack-ruby-bot/commands/hi_spec.rb
+++ b/spec/slack-ruby-bot/commands/hi_spec.rb
@@ -14,4 +14,9 @@ describe SlackRubyBot::Commands::Hi do
   it 'says hi to @bot: ' do
     expect(message: "<@#{SlackRubyBot.config.user_id}>: hi").to respond_with_slack_message('Hi <@user>!')
   end
+  it 'says hi does not respond when mute' do
+    SlackRubyBot::Config.mute = true
+    expect(message: "#{SlackRubyBot.config.user} hi").to not_respond
+    SlackRubyBot::Config.mute = true
+  end
 end

--- a/spec/slack-ruby-bot/commands/unknown_spec.rb
+++ b/spec/slack-ruby-bot/commands/unknown_spec.rb
@@ -12,4 +12,9 @@ describe SlackRubyBot::Commands::Unknown do
     expect(SlackRubyBot::Commands::Base).to_not receive(:send_message)
     message_hook.call(client, Hashie::Mash.new(text: ':((', channel: 'channel', user: 'user'))
   end
+  it 'invalid command does not respond when mute' do
+    SlackRubyBot::Config.mute = true
+    expect(message: "#{SlackRubyBot.config.user} foobar").to not_respond
+    SlackRubyBot::Config.mute = false
+  end
 end


### PR DESCRIPTION
In some business settings we want to discourage staff from exploring the commands a bot will respond to. Letting the bot respond to "hi," "help," "about," and printing information when an unknown/invalid command are entered are to be discouraged.

The mute option does as the name implies. Any built-in command response is muted as are "help" requests for non-built-in commands.

Right now the config option is named `mute` but I am open to another term that may be more descriptive.