### PR TITLE
Lp/on serve instance methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.4 (date)
 
 * Your contribution here.
+* [#147](https://github.com/slack-ruby/slack-ruby-bot/pull/147): Adds `server.on` as a shortcut for `hooks.add` and deprecate `hooks` method - [@laertispappas](https://github.com/laertispappas).
 * [#143](https://github.com/slack-ruby/slack-ruby-bot/pull/143): Provide `permitted?` method to allow for simple authorization extensions - [@chuckremes](https://github.com/chuckremes).
 
 ### 0.10.3 (06/15/2017)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,25 @@
 Upgrading SlackRubyBot
 ======================
 
+### Upgrading to >= 0.10.4
+
+#### Replace `server.hooks.add` with `server.on`
+
+We have deprecated `SlackRubyBot::Server#hooks` in favor of `SlackRubyBot::Server#on` instance method. All users using `SlackRubyBot::Server#hooks` method should
+change their codebase and use the new method instead. Method signature is not affected.
+
+Example:
+
+```ruby
+  # Given server is an instance of SlackRubyBot::Server
+  #
+  # Before
+  server.hooks.add :hello, Greet.new
+
+  # After
+  server.on :hello, Greet.new
+```
+
 ### Upgrading to >= 0.9.0
 
 #### Add giphy to your Gemfile for GIF support

--- a/lib/slack-ruby-bot/hooks/hook_support.rb
+++ b/lib/slack-ruby-bot/hooks/hook_support.rb
@@ -21,6 +21,10 @@ module SlackRubyBot
         @hooks ||= SlackRubyBot::Hooks::Set.new
       end
 
+      def on(event_name, handler)
+        hooks.add(event_name, handler)
+      end
+
       def flush_hook_blocks
         return nil unless self.class.hook_blocks
 

--- a/lib/slack-ruby-bot/hooks/hook_support.rb
+++ b/lib/slack-ruby-bot/hooks/hook_support.rb
@@ -18,11 +18,12 @@ module SlackRubyBot
 
       # Instance stuff
       def hooks
-        @hooks ||= SlackRubyBot::Hooks::Set.new
+        warn Kernel.caller.first + ' [DEPRECATION] `hooks` method is deprecated. Please use `server.on` instead to register a hook.'
+        _hooks
       end
 
       def on(event_name, handler)
-        hooks.add(event_name, handler)
+        _hooks.add(event_name, handler)
       end
 
       def flush_hook_blocks
@@ -31,11 +32,18 @@ module SlackRubyBot
         add_hook_handlers(self.class.hook_blocks)
       end
 
+      # TODO: This should be deprecated in favor of `on`
       def add_hook_handlers(handler_hash)
         handler_hash.each do |hook, handlers|
-          Array(handlers).each { |handler| hooks.add(hook, handler) }
+          Array(handlers).each { |handler| on(hook, handler) }
         end
       end
+
+      # Temp use this method in order to deprecate `hooks` and revisit
+      def _hooks
+        @hooks ||= SlackRubyBot::Hooks::Set.new
+      end
+      private :_hooks
     end
   end
 end

--- a/lib/slack-ruby-bot/hooks/set.rb
+++ b/lib/slack-ruby-bot/hooks/set.rb
@@ -11,12 +11,10 @@ module SlackRubyBot
       end
 
       def add(hook_name, handler)
-        if handlers[hook_name].present?
-          handlers[hook_name] << handler
-        else
-          handlers[hook_name] = [handler]
-          register_callback(hook_name)
-        end
+        handlers[hook_name] ||= ::Set.new
+        handlers[hook_name] << handler
+
+        register_callback(hook_name)
       end
 
       def client=(client)

--- a/lib/slack-ruby-bot/server.rb
+++ b/lib/slack-ruby-bot/server.rb
@@ -101,7 +101,7 @@ module SlackRubyBot
           @client = nil
           restart! unless @stopping
         end
-        hooks.client = client
+        _hooks.client = client
 
         client
       end

--- a/spec/slack-ruby-bot/hooks/hook_support_spec.rb
+++ b/spec/slack-ruby-bot/hooks/hook_support_spec.rb
@@ -35,11 +35,11 @@ describe SlackRubyBot::Hooks::HookSupport do
     it 'registers class hook blocks as hook handlers in set' do
       object = subject.new
 
-      expect(object.hooks).to receive(:add).exactly(3).times.and_call_original
+      expect(object.send(:_hooks)).to receive(:add).exactly(3).times.and_call_original
 
       expect do
         object.flush_hook_blocks
-      end.to change { object.hooks.handlers.size }.by(2)
+      end.to change { object.send(:_hooks).handlers.size }.by(2)
     end
   end
 
@@ -49,8 +49,20 @@ describe SlackRubyBot::Hooks::HookSupport do
       event_name = :message_received
       handler = ->(_, _) {}
 
-      expect(subject.hooks).to receive(:add).with(event_name, handler).and_call_original
+      expect(subject.send(:_hooks)).to receive(:add).with(event_name, handler).and_call_original
       subject.on(event_name, handler)
+    end
+  end
+
+  describe '#hooks' do
+    subject { super().new }
+    it { expect(subject.hooks).to eq subject.send(:_hooks) }
+  end
+
+  describe '#_hooks' do
+    it 'returns a SlackRubyBot::Hooks::Set instance' do
+      hooks_set = subject.new.send(:_hooks)
+      expect(hooks_set).to be_a SlackRubyBot::Hooks::Set
     end
   end
 end

--- a/spec/slack-ruby-bot/hooks/hook_support_spec.rb
+++ b/spec/slack-ruby-bot/hooks/hook_support_spec.rb
@@ -42,4 +42,15 @@ describe SlackRubyBot::Hooks::HookSupport do
       end.to change { object.hooks.handlers.size }.by(2)
     end
   end
+
+  describe '#on' do
+    subject { super().new }
+    it 'delegates to `hooks.add` method' do
+      event_name = :message_received
+      handler = ->(_, _) {}
+
+      expect(subject.hooks).to receive(:add).with(event_name, handler).and_call_original
+      subject.on(event_name, handler)
+    end
+  end
 end

--- a/spec/slack-ruby-bot/hooks/set_spec.rb
+++ b/spec/slack-ruby-bot/hooks/set_spec.rb
@@ -12,7 +12,7 @@ describe SlackRubyBot::Hooks::Set do
       end.to change(subject, :handlers)
 
       expect(subject.handlers).to have_key(:message)
-      expect(subject.handlers[:message]).to eq [handler]
+      expect(subject.handlers[:message]).to eq Set.new.add(handler)
     end
 
     it 'lets you add multiple handlers for the same hook' do
@@ -25,7 +25,7 @@ describe SlackRubyBot::Hooks::Set do
       end.to change(subject, :handlers)
 
       expect(subject.handlers).to have_key(:message)
-      expect(subject.handlers[:message]).to eq [handler_1, handler_2]
+      expect(subject.handlers[:message]).to eq Set.new([handler_1, handler_2])
     end
   end
 


### PR DESCRIPTION
* Addresses #62 and registers a hook using `server.on` instead of `hooks.add`
* Changes hooks data structure from `Array` to a `Set`
* Deprecates `hooks` method
