### PR TITLE
Add `logger` configuration to output log to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.4 (date)
 
 * Your contribution here.
+* [#149](https://github.com/slack-ruby/slack-ruby-bot/pull/149): Add `logger` configuration to set a custom logger - [@upscent](https://github.com/upscent).
 * [#147](https://github.com/slack-ruby/slack-ruby-bot/pull/147): Adds `server.on` as a shortcut for `hooks.add` and deprecate `hooks` method - [@laertispappas](https://github.com/laertispappas).
 * [#143](https://github.com/slack-ruby/slack-ruby-bot/pull/143): Provide `permitted?` method to allow for simple authorization extensions - [@chuckremes](https://github.com/chuckremes).
 

--- a/README.md
+++ b/README.md
@@ -378,10 +378,20 @@ end
 
 ### Logging
 
-By default bots set a logger to `STDOUT` with `DEBUG` level. The logger is used in both the RealTime and Web clients. Silence logger as follows.
+By default bots set a logger to `$stdout` with `DEBUG` level. The logger is used in both the RealTime and Web clients.
+
+Silence logger as follows.
 
 ```ruby
 SlackRubyBot::Client.logger.level = Logger::WARN
+```
+
+If you wish to customize logger, set `logger` to your logger.
+
+```ruby
+SlackRubyBot.configure do |config|
+  config.logger = Logger.new("slack-ruby-bot.log", "daily")
+end
 ```
 
 ### Advanced Integration

--- a/lib/slack-ruby-bot/config.rb
+++ b/lib/slack-ruby-bot/config.rb
@@ -2,7 +2,7 @@ module SlackRubyBot
   module Config
     extend self
 
-    ATTRS = [:token, :url, :aliases, :user, :user_id, :team, :team_id, :allow_message_loops, :send_gifs].freeze
+    ATTRS = [:token, :url, :aliases, :user, :user_id, :team, :team_id, :allow_message_loops, :send_gifs, :logger].freeze
     attr_accessor(*ATTRS)
 
     def allow_message_loops?

--- a/lib/slack-ruby-bot/support/loggable.rb
+++ b/lib/slack-ruby-bot/support/loggable.rb
@@ -9,7 +9,7 @@ module SlackRubyBot
       def logger
         @logger ||= begin
           $stdout.sync = true
-          Logger.new(STDOUT)
+          Logger.new($stdout)
         end
       end
     end

--- a/lib/slack-ruby-bot/support/loggable.rb
+++ b/lib/slack-ruby-bot/support/loggable.rb
@@ -7,7 +7,7 @@ module SlackRubyBot
 
     module ClassMethods
       def logger
-        @logger ||= begin
+        @logger ||= SlackRubyBot::Config.logger || begin
           $stdout.sync = true
           Logger.new($stdout)
         end

--- a/spec/slack-ruby-bot/support/loggable_spec.rb
+++ b/spec/slack-ruby-bot/support/loggable_spec.rb
@@ -1,22 +1,22 @@
 describe SlackRubyBot::Loggable do
-  let! :class_with_logger do
-    Class.new(SlackRubyBot::Commands::Base) do
-      def public_logger
-        logger
-      end
-    end
-  end
-  let! :child_class_with_logger do
-    Class.new(class_with_logger) do
-      def public_logger
-        logger
-      end
-    end
-  end
+  let!(:class_with_logger)       { Class.new SlackRubyBot::Commands::Base }
+  let!(:child_class_with_logger) { Class.new class_with_logger }
   describe 'logger for class' do
-    it do
-      expect(class_with_logger.logger).to be_kind_of Logger
-      expect(child_class_with_logger.logger).to be_kind_of Logger
+    context 'set logger by config' do
+      let(:logger) { double 'logger' }
+      it do
+        SlackRubyBot.configure do |config|
+          config.logger = logger
+        end
+        expect(class_with_logger.logger).to eq logger
+        expect(child_class_with_logger.logger).to eq logger
+      end
+    end
+    context 'default logger' do
+      it do
+        expect(class_with_logger.logger).to be_kind_of Logger
+        expect(child_class_with_logger.logger).to be_kind_of Logger
+      end
     end
     it 'should be cached' do
       first_logger = class_with_logger.logger
@@ -30,18 +30,9 @@ describe SlackRubyBot::Loggable do
     end
   end
   describe 'logger for instance' do
-    it do
-      expect(class_with_logger.new.public_logger).to be_kind_of Logger
-    end
-    it 'should be cached' do
-      first_logger = class_with_logger.new.public_logger
-      second_logger = class_with_logger.new.public_logger
-      expect(first_logger.object_id).to eq second_logger.object_id
-    end
-    it 'should not be shared by a child class' do
-      first_logger = class_with_logger.new.public_logger
-      second_logger = child_class_with_logger.new.public_logger
-      expect(first_logger.object_id).to_not eq second_logger.object_id
+    it 'same with one for class' do
+      expect(class_with_logger.new.logger.object_id).to eq class_with_logger.logger.object_id
+      expect(child_class_with_logger.new.logger.object_id).to eq child_class_with_logger.logger.object_id
     end
   end
 end


### PR DESCRIPTION
By default, slack-ruby-bot outputs logs to `STDOUT`.
We can silence log by changing log level, but can't change output destination.

So I added logger configuration to set custom logger.