### PR TITLE
Allow testing of commands that return multiple messages with respond_with_slack_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.5 (Next)
 
 * Refactored `SlackRubyBot::MVC::Controller::Base`, consolidated ivar handling, centralized object allocations and DRYed up the code - [@chuckremes](https://github.com/chuckremes).
+* [#157](https://github.com/slack-ruby/slack-ruby-bot/pull/157): Added support for checking multiple responses at once via new `respond_with_slack_messages` matcher, and single response out of multiple responses to `response_with_slack_message` matcher - [@gcraig99](https://github.com/gcraig99) 
 * Your contribution here.
 
 ### 0.10.4 (07/05/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.10.5 (Next)
 
 * Refactored `SlackRubyBot::MVC::Controller::Base`, consolidated ivar handling, centralized object allocations and DRYed up the code - [@chuckremes](https://github.com/chuckremes).
-* [#157](https://github.com/slack-ruby/slack-ruby-bot/pull/157): Added support for checking multiple responses at once via new `respond_with_slack_messages` matcher, and single response out of multiple responses to `response_with_slack_message` matcher - [@gcraig99](https://github.com/gcraig99) 
+* [#157](https://github.com/slack-ruby/slack-ruby-bot/pull/157): Added `respond_with_slack_messages` - [@gcraig99](https://github.com/gcraig99). 
 * Your contribution here.
 
 ### 0.10.4 (07/05/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.10.5 (Next)
 
 * Refactored `SlackRubyBot::MVC::Controller::Base`, consolidated ivar handling, centralized object allocations and DRYed up the code - [@chuckremes](https://github.com/chuckremes).
-* [#157](https://github.com/slack-ruby/slack-ruby-bot/pull/157): Added `respond_with_slack_messages` - [@gcraig99](https://github.com/gcraig99). 
+* [#157](https://github.com/slack-ruby/slack-ruby-bot/pull/157): Added `respond_with_slack_messages` expectation - [@gcraig99](https://github.com/gcraig99).
 * Your contribution here.
 
 ### 0.10.4 (07/05/2017)

--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Slack-ruby-bot ships with a number of shared RSpec behaviors that can be used in
 
 * [behaves like a slack bot](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb): A bot quacks like a Slack Ruby bot.
 * [respond with slack message](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb): The bot responds with a message.
+* [respond with slack messages](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb): The bot responds with a set of message.
 * [respond with error](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_error.rb): An exception is raised inside a bot command.
 
 Require `slack-ruby-bot/rspec` in your `spec_helper.rb` along with the following dependencies in Gemfile.

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Slack-ruby-bot ships with a number of shared RSpec behaviors that can be used in
 
 * [behaves like a slack bot](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb): A bot quacks like a Slack Ruby bot.
 * [respond with slack message](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb): The bot responds with a message.
-* [respond with slack messages](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb): The bot responds with a set of message.
+* [respond with slack messages](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb): The bot responds with a multiple messages.
 * [respond with error](lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_error.rb): An exception is raised inside a bot command.
 
 Require `slack-ruby-bot/rspec` in your `spec_helper.rb` along with the following dependencies in Gemfile.

--- a/lib/slack-ruby-bot/rspec/support/fixtures/slack/migration_in_progress.yml
+++ b/lib/slack-ruby-bot/rspec/support/fixtures/slack/migration_in_progress.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://slack.com/api/rtm.start
+    uri: https://slack.com/api/rtm.connect
     body:
       string: token=token
   response:
@@ -16,7 +16,7 @@ http_interactions:
   recorded_at: Tue, 28 Apr 2015 12:55:22 GMT
 - request:
     method: post
-    uri: https://slack.com/api/rtm.start
+    uri: https://slack.com/api/rtm.connect
     body:
       string: token=token
   response:

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
@@ -1,5 +1,6 @@
 require 'rspec/expectations'
 RSpec::Matchers.define :respond_with_slack_message do |expected|
+  include SlackRubyBot::SpecHelpers
   match do |actual|
     client = respond_to?(:client) ? send(:client) : SlackRubyBot::Client.new
     def client.test_messages
@@ -27,12 +28,5 @@ RSpec::Matchers.define :respond_with_slack_message do |expected|
   failure_message do |_actual|
     message = "expected to receive message with text: #{expected} once, received #{@messages}"
     message
-  end
-
-  private
-
-  def parse(actual)
-    actual = { message: actual } unless actual.is_a?(Hash)
-    [actual[:channel] || 'channel', actual[:user] || 'user', actual[:message]]
   end
 end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
@@ -1,12 +1,16 @@
 require 'rspec/expectations'
-
 RSpec::Matchers.define :respond_with_slack_message do |expected|
   match do |actual|
-    client = if respond_to?(:client)
-               send(:client)
-             else
-               SlackRubyBot::Client.new
-             end
+    client = respond_to?(:client) ? send(:client) : SlackRubyBot::Client.new
+    def client.test_messages
+      @test_received_messages
+    end
+
+    def client.say(options = {})
+      super
+      @test_received_messages = @test_received_messages.nil? ? '' : @test_received_messages
+      @test_received_messages += "#{options.inspect}\n"
+    end
 
     message_command = SlackRubyBot::Hooks::Message.new
     channel, user, message = parse(actual)
@@ -15,8 +19,14 @@ RSpec::Matchers.define :respond_with_slack_message do |expected|
 
     allow(client).to receive(:message)
     message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
-    expect(client).to have_received(:message).with(channel: channel, text: expected).once
+    @messages = client.test_messages
+    expect(client).to have_received(:message).with(channel: channel, text: expected).once, -> { return }
     true
+  end
+
+  failure_message do |_actual|
+    message = "expected to receive message with text: #{expected} once, received #{@messages}"
+    message
   end
 
   private

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
@@ -9,8 +9,8 @@ RSpec::Matchers.define :respond_with_slack_message do |expected|
 
     def client.say(options = {})
       super
-      @test_received_messages = @test_received_messages.nil? ? '' : @test_received_messages
-      @test_received_messages += "#{options.inspect}\n"
+      @test_received_messages = @test_received_messages.nil? ? [] : @test_received_messages
+      @test_received_messages.push options
     end
 
     message_command = SlackRubyBot::Hooks::Message.new
@@ -26,7 +26,8 @@ RSpec::Matchers.define :respond_with_slack_message do |expected|
   end
 
   failure_message do |_actual|
-    message = "expected to receive message with text: #{expected} once, received #{@messages}"
+    message = "expected to receive message with text: #{expected} once,\n received:"
+    message += @messages.count.zero? ? 'No response messages received' : @messages.inspect
     message
   end
 end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
@@ -21,7 +21,7 @@ RSpec::Matchers.define :respond_with_slack_message do |expected|
     allow(client).to receive(:message)
     message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
     @messages = client.test_messages
-    expect(client).to have_received(:message).with(channel: channel, text: expected).once, -> { return }
+    expect(client).to have_received(:message).with(channel: channel, text: expected).once
     true
   end
 

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -2,11 +2,16 @@ require 'rspec/expectations'
 RSpec::Matchers.define :respond_with_slack_messages do |expected|
   match do |actual|
     raise ArgumentError, 'respond_with_slack_messages expects an array of ordered responses' unless expected.is_a? Array
-    client = if respond_to?(:client)
-               send(:client)
-             else
-               SlackRubyBot::Client.new
-             end
+    client = respond_to?(:client) ? send(:client) : SlackRubyBot::Client.new
+    def client.test_messages
+      @test_received_messages
+    end
+
+    def client.say(options = {})
+      super
+      @test_received_messages = @test_received_messages.nil? ? '' : @test_received_messages
+      @test_received_messages += "#{options.inspect}\n"
+    end
 
     message_command = SlackRubyBot::Hooks::Message.new
     channel, user, message = parse(actual)
@@ -15,10 +20,15 @@ RSpec::Matchers.define :respond_with_slack_messages do |expected|
 
     allow(client).to receive(:message)
     message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
+    @messages = client.test_messages
     expected.each do |exp|
       expect(client).to have_received(:message).with(channel: channel, text: exp).once
     end
     true
+  end
+  failure_message do |_actual|
+    message = "expected to receive messages in order with text: #{expected.join("\n")} got: #{@messages}"
+    message
   end
 
 private

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -22,15 +22,16 @@ RSpec::Matchers.define :respond_with_slack_messages do |expected|
     allow(client).to receive(:message)
     message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
     @messages = client.test_messages
+    @responses = []
     expected.each do |exp|
-      expect(client).to have_received(:message).with(channel: channel, text: exp).once
+      @responses.push(expect(client).to(have_received(:message).with(channel: channel, text: exp).once))
     end
     true
   end
   failure_message do |_actual|
     message = ''
     expected.each do |exp|
-      message += "Expected text: #{exp}, got #{@messages[expected.index(exp)] || 'No Response'}\n"
+      message += "Expected text: #{exp}, got #{@messages[expected.index(exp)] || 'No Response'}\n" unless @responses[expected.index(exp)]
     end
     message
   end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -28,8 +28,10 @@ RSpec::Matchers.define :respond_with_slack_messages do |expected|
     true
   end
   failure_message do |_actual|
-    message = "expected to receive messages in order with text: #{expected}\n received:"
-    message += @messages.count.zero? ? 'No response messages received' : @messages.inspect
+    message = ''
+    expected.each do |exp|
+      message += "Expected text: #{exp}, got #{@messages[expected.index(exp)] || 'No Response'}"
+    end
     message
   end
 end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -10,8 +10,8 @@ RSpec::Matchers.define :respond_with_slack_messages do |expected|
 
     def client.say(options = {})
       super
-      @test_received_messages = @test_received_messages.nil? ? '' : @test_received_messages
-      @test_received_messages += "#{options.inspect}\n"
+      @test_received_messages = @test_received_messages.nil? ? [] : @test_received_messages
+      @test_received_messages.push options
     end
 
     message_command = SlackRubyBot::Hooks::Message.new
@@ -28,7 +28,8 @@ RSpec::Matchers.define :respond_with_slack_messages do |expected|
     true
   end
   failure_message do |_actual|
-    message = "expected to receive messages in order with text: #{expected.join("\n")} got: #{@messages}"
+    message = "expected to receive messages in order with text: #{expected}\n received:"
+    message += @messages.count.zero? ? 'No response messages received' : @messages.inspect
     message
   end
 end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -1,7 +1,7 @@
 require 'rspec/expectations'
-
-RSpec::Matchers.define :respond_with_slack_message do |expected|
+RSpec::Matchers.define :respond_with_slack_messages do |expected|
   match do |actual|
+    raise ArgumentError, 'respond_with_slack_messages expects an array of ordered responses' unless expected.is_a? Array
     client = if respond_to?(:client)
                send(:client)
              else
@@ -15,11 +15,13 @@ RSpec::Matchers.define :respond_with_slack_message do |expected|
 
     allow(client).to receive(:message)
     message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
-    expect(client).to have_received(:message).with(channel: channel, text: expected).once
+    expected.each do |exp|
+      expect(client).to have_received(:message).with(channel: channel, text: exp).once
+    end
     true
   end
 
-  private
+private
 
   def parse(actual)
     actual = { message: actual } unless actual.is_a?(Hash)

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -30,7 +30,7 @@ RSpec::Matchers.define :respond_with_slack_messages do |expected|
   failure_message do |_actual|
     message = ''
     expected.each do |exp|
-      message += "Expected text: #{exp}, got #{@messages[expected.index(exp)] || 'No Response'}"
+      message += "Expected text: #{exp}, got #{@messages[expected.index(exp)] || 'No Response'}\n"
     end
     message
   end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -1,7 +1,8 @@
 require 'rspec/expectations'
 RSpec::Matchers.define :respond_with_slack_messages do |expected|
+  include SlackRubyBot::SpecHelpers
   match do |actual|
-    raise ArgumentError, 'respond_with_slack_messages expects an array of ordered responses' unless expected.is_a? Array
+    raise ArgumentError, 'respond_with_slack_messages expects an array of ordered responses' unless expected.respond_to? :each
     client = respond_to?(:client) ? send(:client) : SlackRubyBot::Client.new
     def client.test_messages
       @test_received_messages
@@ -29,12 +30,5 @@ RSpec::Matchers.define :respond_with_slack_messages do |expected|
   failure_message do |_actual|
     message = "expected to receive messages in order with text: #{expected.join("\n")} got: #{@messages}"
     message
-  end
-
-private
-
-  def parse(actual)
-    actual = { message: actual } unless actual.is_a?(Hash)
-    [actual[:channel] || 'channel', actual[:user] || 'user', actual[:message]]
   end
 end

--- a/lib/slack-ruby-bot/rspec/support/spec_helpers.rb
+++ b/lib/slack-ruby-bot/rspec/support/spec_helpers.rb
@@ -1,0 +1,10 @@
+module SlackRubyBot
+  module SpecHelpers
+    private
+
+    def parse(actual)
+      actual = { message: actual } unless actual.is_a?(Hash)
+      [actual[:channel] || 'channel', actual[:user] || 'user', actual[:message]]
+    end
+  end
+end

--- a/spec/slack-ruby-bot/rspec/respond_with_slack_message_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_slack_message_spec.rb
@@ -1,0 +1,30 @@
+describe RSpec do
+  let! :command do
+    Class.new(SlackRubyBot::Commands::Base) do
+      command 'single message' do |client, data, _match|
+        client.say(text: 'single response', channel: data.channel)
+      end
+      command 'respond 5 times' do |client, data, _match|
+        5.times do |i|
+          client.say(text: "response #{i}", channel: data.channel)
+        end
+      end
+    end
+  end
+
+  def app
+    SlackRubyBot::App.new
+  end
+  it 'respond_with_single_message_using_regex_match' do
+    expect(message: "#{SlackRubyBot.config.user} single message")
+      .to respond_with_slack_message(/single response/i)
+  end
+  it 'respond_with_single_message_using_string_match' do
+    expect(message: "#{SlackRubyBot.config.user} single message")
+      .to respond_with_slack_message('single response')
+  end
+  it 'respond_with_multiple_messages_looking_for_single_match' do
+    expect(message: "#{SlackRubyBot.config.user} respond 5 times")
+      .to respond_with_slack_message('response 1')
+  end
+end

--- a/spec/slack-ruby-bot/rspec/respond_with_slack_message_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_slack_message_spec.rb
@@ -19,6 +19,14 @@ describe RSpec do
     expect(message: "#{SlackRubyBot.config.user} single message")
       .to respond_with_slack_message(/single response/i)
   end
+  it 'respond_with_single_message_using_partial_regex_match' do
+    expect(message: "#{SlackRubyBot.config.user} single message")
+      .to respond_with_slack_message(/si[n|N]gle/)
+  end
+  it 'not_respond_with_single_message_using_bad_regex_match' do
+    expect(message: "#{SlackRubyBot.config.user} single message")
+      .not_to respond_with_slack_message(/si[g|G]gle/)
+  end
   it 'respond_with_single_message_using_string_match' do
     expect(message: "#{SlackRubyBot.config.user} single message")
       .to respond_with_slack_message('single response')
@@ -26,5 +34,9 @@ describe RSpec do
   it 'respond_with_multiple_messages_looking_for_single_match' do
     expect(message: "#{SlackRubyBot.config.user} respond 5 times")
       .to respond_with_slack_message('response 1')
+  end
+  it 'respond_with_multiple_messages_no_match' do
+    expect(message: "#{SlackRubyBot.config.user} respond 5 times")
+      .not_to respond_with_slack_message('response 7')
   end
 end

--- a/spec/slack-ruby-bot/rspec/respond_with_slack_messages_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_slack_messages_spec.rb
@@ -1,0 +1,28 @@
+describe RSpec do
+  let! :command do
+    Class.new(SlackRubyBot::Commands::Base) do
+      command 'respond 5 times' do |client, data, _match|
+        5.times do |i|
+          client.say(text: "response #{i}", channel: data.channel)
+        end
+      end
+    end
+  end
+
+  def app
+    SlackRubyBot::App.new
+  end
+
+  it 'respond_with_multiple_messages_using_regex_matches' do
+    expected_responses = []
+    5.times { |i| expected_responses.push(/response #{i}/i) }
+    expect(message: "#{SlackRubyBot.config.user} respond 5 times")
+      .to respond_with_slack_messages(expected_responses)
+  end
+  it 'respond_with_multiple_messages_using_string_matches' do
+    expected_responses = []
+    5.times { |i| expected_responses.push("response #{i}") }
+    expect(message: "#{SlackRubyBot.config.user} respond 5 times")
+      .to respond_with_slack_messages(expected_responses)
+  end
+end

--- a/spec/slack-ruby-bot/rspec/respond_with_slack_messages_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_slack_messages_spec.rb
@@ -25,4 +25,10 @@ describe RSpec do
     expect(message: "#{SlackRubyBot.config.user} respond 5 times")
       .to respond_with_slack_messages(expected_responses)
   end
+  it 'not_respond_with_multiple_messages_using_string_matches' do
+    expected_responses = []
+    6.times { |i| expected_responses.push("response #{i}") }
+    expect(message: "#{SlackRubyBot.config.user} respond 5 times")
+      .not_to respond_with_slack_messages(expected_responses)
+  end
 end


### PR DESCRIPTION
Allows testing of a single response out of multiple responses, and also allows testing of all responses from a single command call. 

Resolves #135 