### PR TITLE
Fixed expectation failures when client.say is passed extra arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Refactored `SlackRubyBot::MVC::Controller::Base`, consolidated ivar handling, centralized object allocations and DRYed up the code - [@chuckremes](https://github.com/chuckremes).
 * [#157](https://github.com/slack-ruby/slack-ruby-bot/pull/157): Added `respond_with_slack_messages` expectation - [@gcraig99](https://github.com/gcraig99).
-* [#158](https://github.com/slack-ruby/slack-ruby-bot/pull/158): Fixed `respond_with_slack_message(s)` expectation failures - [@gcraig99](https://github.com/gcraig99).
+* [#160](https://github.com/slack-ruby/slack-ruby-bot/pull/160): Fixed `respond_with_slack_message(s)` expectation failures - [@gcraig99](https://github.com/gcraig99).
 * Your contribution here.
 
 ### 0.10.4 (07/05/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Refactored `SlackRubyBot::MVC::Controller::Base`, consolidated ivar handling, centralized object allocations and DRYed up the code - [@chuckremes](https://github.com/chuckremes).
 * [#157](https://github.com/slack-ruby/slack-ruby-bot/pull/157): Added `respond_with_slack_messages` expectation - [@gcraig99](https://github.com/gcraig99).
+* [#158](https://github.com/slack-ruby/slack-ruby-bot/pull/158): Fixed `respond_with_slack_message(s)` expectation failures - [@gcraig99](https://github.com/gcraig99).
 * Your contribution here.
 
 ### 0.10.4 (07/05/2017)

--- a/lib/slack-ruby-bot/rspec/support/fixtures/slack/migration_in_progress.yml
+++ b/lib/slack-ruby-bot/rspec/support/fixtures/slack/migration_in_progress.yml
@@ -28,3 +28,31 @@ http_interactions:
       string: '{"ok":false,"error":"unknown"}'
     http_version:
   recorded_at: Tue, 28 Apr 2015 12:55:22 GMT
+- request:
+    method: post
+    uri: https://slack.com/api/rtm.start
+    body:
+      string: token=token
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: UTF-8
+      string: '{"ok":false,"error":"migration_in_progress"}'
+    http_version:
+  recorded_at: Tue, 28 Apr 2015 12:55:22 GMT
+- request:
+    method: post
+    uri: https://slack.com/api/rtm.start
+    body:
+      string: token=token
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: UTF-8
+      string: '{"ok":false,"error":"unknown"}'
+    http_version:
+  recorded_at: Tue, 28 Apr 2015 12:55:22 GMT

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
@@ -21,7 +21,7 @@ RSpec::Matchers.define :respond_with_slack_message do |expected|
     allow(client).to receive(:message)
     message_command.call(client, Hashie::Mash.new(text: message, channel: channel, user: user))
     @messages = client.test_messages
-    expect(client).to have_received(:message).with(channel: channel, text: expected).once
+    expect(client).to have_received(:message).with(hash_including(channel: channel, text: expected)).once
     true
   end
 

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -24,7 +24,7 @@ RSpec::Matchers.define :respond_with_slack_messages do |expected|
     @messages = client.test_messages
     @responses = []
     expected.each do |exp|
-      @responses.push(expect(client).to(have_received(:message).with(channel: channel, text: exp).once))
+      @responses.push(expect(client).to(have_received(:message).with(hash_including(channel: channel, text: exp)).once))
     end
     true
   end

--- a/spec/slack-ruby-bot/rspec/respond_with_slack_message_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_slack_message_spec.rb
@@ -1,6 +1,9 @@
 describe RSpec do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do
+      command 'single message with as_user' do |client, data, _match|
+        client.say(text: 'single response', channel: data.channel, as_user: true)
+      end
       command 'single message' do |client, data, _match|
         client.say(text: 'single response', channel: data.channel)
       end
@@ -30,6 +33,10 @@ describe RSpec do
   it 'respond_with_single_message_using_string_match' do
     expect(message: "#{SlackRubyBot.config.user} single message")
       .to respond_with_slack_message('single response')
+  end
+  it 'respond_with_single_message_using_regex_match_with_extra_args' do
+    expect(message: "#{SlackRubyBot.config.user} single message with as_user")
+      .to respond_with_slack_message(/single response/i)
   end
   it 'respond_with_multiple_messages_looking_for_single_match' do
     expect(message: "#{SlackRubyBot.config.user} respond 5 times")

--- a/spec/slack-ruby-bot/rspec/respond_with_slack_messages_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_slack_messages_spec.rb
@@ -1,6 +1,11 @@
 describe RSpec do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do
+      command 'respond with as_user' do |client, data, _match|
+        5.times do |i|
+          client.say(text: "response #{i}", channel: data.channel, as_user: true)
+        end
+      end
       command 'respond 5 times' do |client, data, _match|
         5.times do |i|
           client.say(text: "response #{i}", channel: data.channel)
@@ -30,5 +35,11 @@ describe RSpec do
     6.times { |i| expected_responses.push("response #{i}") }
     expect(message: "#{SlackRubyBot.config.user} respond 5 times")
       .not_to respond_with_slack_messages(expected_responses)
+  end
+  it 'respond_with_multiple_messages_using_string_matches_with_extra_arg' do
+    expected_responses = []
+    5.times { |i| expected_responses.push("response #{i}") }
+    expect(message: "#{SlackRubyBot.config.user} respond with as_user")
+      .to respond_with_slack_messages(expected_responses)
   end
 end


### PR DESCRIPTION
 Fixed expectation failures when client.say is passed extra arguments such as **as_user: true**
Added test cases for this situation as well.
Closes #159 