### PR TITLE
Adds info on http_proxy usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.6 (Next)
 
 * Your contribution here.
+* [#174](https://github.com/slack-ruby/slack-ruby-bot/pull/174): adds info on http_proxy usage to README - [@phantomdata](https://github.com/phantomdata).
 * [#173](https://github.com/slack-ruby/slack-ruby-bot/pull/173): Exposing SlackRubyBot::CommandsHelper.find_command_help_attrs - [@alexagranov](https://github.com/alexagranov).
 
 ### 0.10.5 (10/15/2017)

--- a/README.md
+++ b/README.md
@@ -460,6 +460,12 @@ end
 
 For an example of advanced integration that supports multiple teams, see [slack-gamebot](https://github.com/dblock/slack-gamebot) and [playplay.io](http://playplay.io) that is built on top of it.
 
+### Proxy Configuration
+
+There are [a few proxy options](https://github.com/slack-ruby/slack-ruby-client#web-client-options) that can be configured on the `Slack::Web::Client`; but you can also control what proxy options are used by modifying the `http_proxy` environment variable per [Net::HTTP's documentation](https://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#class-Net::HTTP-label-Proxies).
+
+Be aware that Docker on OSX seems to set this erroneously, [causing weird Faraday errors](https://github.com/slack-ruby/slack-ruby-bot/issues/155).  You may need to manually unset it on the command line in this case (`http_proxy="" bundle exec ruby ./my_bot.rb`).
+
 ### Model-View-Controller Design
 
 The `command` method is essentially a controller method that receives input from the outside and acts upon it. Complex behaviors could lead to a long and difficult-to-understand `command` block. A complex `command` block is a candidate for separation into classes conforming to the Model-View-Controller pattern popularized by Rails.

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ For an example of advanced integration that supports multiple teams, see [slack-
 
 There are [a few proxy options](https://github.com/slack-ruby/slack-ruby-client#web-client-options) that can be configured on the `Slack::Web::Client`; but you can also control what proxy options are used by modifying the `http_proxy` environment variable per [Net::HTTP's documentation](https://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#class-Net::HTTP-label-Proxies).
 
-Be aware that Docker on OSX seems to set this erroneously, [causing weird Faraday errors](https://github.com/slack-ruby/slack-ruby-bot/issues/155).  You may need to manually unset it on the command line in this case (`http_proxy="" bundle exec ruby ./my_bot.rb`).
+Be aware that Docker on OSX seems to set this erroneously, [causing an unexpected Faraday error](https://github.com/slack-ruby/slack-ruby-bot/issues/155) (`ERROR -- : Failed to open TCP connection to : (getaddrinfo: Name or service not known) (Faraday::ConnectionFailed)`).  You may need to manually unset it on the command line in this case (`http_proxy="" bundle exec ruby ./my_bot.rb`).
 
 ### Model-View-Controller Design
 


### PR DESCRIPTION
This PR attempts to assist others who may be running into issues with `http_proxy` environment variable being pre-set on their system, which causes Faraday to output an unexpected message about being unable to contact a server.  The behavior of this is documented and discussed over in https://github.com/slack-ruby/slack-ruby-bot/issues/155#issuecomment-354212987.