### PR TITLE
Add failing spec for NotImplementedError with MVC commands

### DIFF
--- a/lib/slack-ruby-bot/rspec/support/bots_for_tests.rb
+++ b/lib/slack-ruby-bot/rspec/support/bots_for_tests.rb
@@ -32,6 +32,9 @@ module Testing
   end
 
   class GreetingsController < SlackRubyBot::MVC::Controller::Base
+    def hallo; end
+
+    def hola; end
   end
 
   class Greetings < SlackRubyBot::Commands::Base

--- a/lib/slack-ruby-bot/rspec/support/bots_for_tests.rb
+++ b/lib/slack-ruby-bot/rspec/support/bots_for_tests.rb
@@ -30,4 +30,13 @@ module Testing
       long_desc 'The long description'
     end
   end
+
+  class GreetingsController < SlackRubyBot::MVC::Controller::Base
+  end
+
+  class Greetings < SlackRubyBot::Commands::Base
+    model = SlackRubyBot::MVC::Model::Base.new
+    view = SlackRubyBot::MVC::View::Base.new
+    @controller = GreetingsController.new(model, view)
+  end
 end

--- a/spec/slack-ruby-bot/commands/not_implemented_spec.rb
+++ b/spec/slack-ruby-bot/commands/not_implemented_spec.rb
@@ -4,6 +4,7 @@ describe SlackRubyBot::Commands::Base do
       command 'not_implemented'
     end
   end
+
   it 'raises not implemented' do
     expect(message: "#{SlackRubyBot.config.user} not_implemented").to respond_with_error(NotImplementedError, 'rubybot not_implemented')
   end

--- a/spec/slack-ruby-bot/commands/unknown_spec.rb
+++ b/spec/slack-ruby-bot/commands/unknown_spec.rb
@@ -2,9 +2,17 @@ describe SlackRubyBot::Commands::Unknown do
   it 'invalid command' do
     expect(message: "#{SlackRubyBot.config.user} foobar").to respond_with_slack_message("Sorry <@user>, I don't understand that command!")
   end
+
   it 'invalid command with @bot:' do
     expect(message: "<@#{SlackRubyBot.config.user_id}>: foobar").to respond_with_slack_message("Sorry <@user>, I don't understand that command!")
   end
+
+  it 'command matching the name of a commands class that uses an mvc controller' do
+    expect(
+      message: "<@#{SlackRubyBot.config.user_id}>: greetings"
+    ).to respond_with_slack_message("Sorry <@user>, I don't understand that command!")
+  end
+
   it 'does not respond to sad face' do
     client = SlackRubyBot::Client.new
     message_hook = SlackRubyBot::Hooks::Message.new


### PR DESCRIPTION
- Looks like if a command name matches the user input, and the controller doesn't write a method handling it, it errors

Requested on https://github.com/slack-ruby/slack-ruby-bot/issues/175