### PR TITLE
Allow multiline expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Your contribution here.
 * [#173](https://github.com/slack-ruby/slack-ruby-bot/pull/173): Exposing SlackRubyBot::CommandsHelper.find_command_help_attrs - [@alexagranov](https://github.com/alexagranov).
+* [#179](https://github.com/slack-ruby/slack-ruby-bot/pull/179): Allow multiline expression - [@tiagotex](https://github.com/tiagotex).
 
 ### 0.10.5 (10/15/2017)
 

--- a/lib/slack-ruby-bot/commands/base.rb
+++ b/lib/slack-ruby-bot/commands/base.rb
@@ -46,7 +46,7 @@ module SlackRubyBot
 
         def command(*values, &block)
           values = values.map { |value| value.is_a?(Regexp) ? value.source : Regexp.escape(value) }.join('|')
-          match Regexp.new("^#{bot_matcher}[\\s]+(?<command>#{values})([\\s]+(?<expression>.*)|)$", Regexp::IGNORECASE), &block
+          match Regexp.new("^#{bot_matcher}[\\s]+(?<command>#{values})([\\s]+(?<expression>.*)|)$", Regexp::IGNORECASE | Regexp::MULTILINE), &block
         end
 
         def invoke(client, data)

--- a/spec/slack-ruby-bot/commands/commands_regexp_escape_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_regexp_escape_spec.rb
@@ -6,10 +6,16 @@ describe SlackRubyBot::Commands do
       end
     end
   end
+
   def app
     SlackRubyBot::App.new
   end
+
   it 'does not return error' do
     expect(message: "#{SlackRubyBot.config.user} ( /").to respond_with_slack_message('(: /')
+  end
+
+  it 'allows multiline expression' do
+    expect(message: "#{SlackRubyBot.config.user} (\n1\n2").to respond_with_slack_message("(: 1\n2")
   end
 end


### PR DESCRIPTION
I'm trying to create a bot that expects a command like:

```
todo:
first
second
```

In the current version `match[:expression]` would return:

```
first
```

It seems like command regex parser doesn't allow multiline, I fixed it using `Regexp::MULTILINE`, now `match[:expression]` returns:

```
first
second
```

Is this something you would be interested in supporting?