### PR TITLE
Add missing test dependency to README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#180](https://github.com/slack-ruby/slack-ruby-bot/pull/180): Allow to respond to text in attachments #177 - [@mdudzinski](https://github.com/mdudzinski).
 * [#173](https://github.com/slack-ruby/slack-ruby-bot/pull/173): Exposing SlackRubyBot::CommandsHelper.find_command_help_attrs - [@alexagranov](https://github.com/alexagranov).
 * [#179](https://github.com/slack-ruby/slack-ruby-bot/pull/179): Allow multiline expression - [@tiagotex](https://github.com/tiagotex).
+* [#183](https://github.com/slack-ruby/slack-ruby-bot/pull/183): Add missing test dependency to readme.md - [@hoshinotsuyoshi](https://github.com/hoshinotsuyoshi).
 
 ### 0.10.5 (10/15/2017)
 

--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ Require `slack-ruby-bot/rspec` in your `spec_helper.rb` along with the following
 
 ```ruby
 group :development, :test do
+  gem 'rack-test'
   gem 'rspec'
   gem 'vcr'
   gem 'webmock'


### PR DESCRIPTION
When using `slack-ruby-bot/rspec`,  `rack-test` gem is needed because of [this](https://github.com/slack-ruby/slack-ruby-bot/blob/v0.10.5/lib/slack-ruby-bot/rspec.rb#L5)

Without this gem,  I cannot pass my tests. 

```sh
$ bundle exec rspec
(...snip...)
/Users/hoshino/go/src/github.com/hoshinotsuyoshi/dicebot/vendor/bundle/ruby/2.5.0/gems/slack-ruby-bot-0.10.5/lib/slack-ruby-bot/rspec.rb:5:in `require': cannot load such file -- rack/test (LoadError)
```

TUTORIAL.md is correct.

https://github.com/slack-ruby/slack-ruby-bot/blob/v0.10.5/TUTORIAL.md#gemfile