### PR TITLE
Update Syntaxes for Ruby 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,5 +7,8 @@ AllCops:
 
 inherit_from: .rubocop_todo.yml
 
-#Style/FrozenStringLiteralComment:
-#  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/ExtendSelf:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,5 +7,5 @@ AllCops:
 
 inherit_from: .rubocop_todo.yml
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
+#Style/FrozenStringLiteralComment:
+#  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,5 +3,9 @@ AllCops:
     - vendor/**/*
     - examples/**/vendor/**/*
     - bin/**/*
+  TargetRubyVersion: 2.5
 
 inherit_from: .rubocop_todo.yml
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.11.1 (Next)
 
 * Your contribution here.
+* [#186](https://github.com/slack-ruby/slack-ruby-bot/pull/186): Update syntaxes for ruby 2.5 - [@hanasuke](https://github.com/hanasuke).
 
 ### 0.11.0 (04/02/2018)
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 danger.import_dangerfile(gem: 'slack-ruby-danger')

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler'
 require 'bundler/gem_tasks'

--- a/examples/inventory/Gemfile
+++ b/examples/inventory/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gem 'celluloid-io'

--- a/examples/inventory/inventorybot.rb
+++ b/examples/inventory/inventorybot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot'
 require 'sqlite3'
 

--- a/examples/market/Gemfile
+++ b/examples/market/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gem 'faye-websocket'

--- a/examples/market/marketbot.rb
+++ b/examples/market/marketbot.rb
@@ -15,7 +15,7 @@ class MarketBot < SlackRubyBot::Bot
             fallback: "#{quote.name} (#{quote.symbol}): $#{quote.last_trade_price}",
             title: "#{quote.name} (#{quote.symbol})",
             text: "$#{quote.last_trade_price} (#{quote.change_in_percent})",
-            color: quote.change.to_f > 0 ? '#00FF00' : '#FF0000'
+            color: quote.change.to_f.positive? ? '#00FF00' : '#FF0000'
           }
         ]
       )

--- a/examples/market/marketbot.rb
+++ b/examples/market/marketbot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot'
 require 'yahoo-finance'
 

--- a/examples/minimal/Gemfile
+++ b/examples/minimal/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gem 'celluloid-io'

--- a/examples/minimal/pongbot.rb
+++ b/examples/minimal/pongbot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot'
 
 class Bot < SlackRubyBot::Bot

--- a/examples/weather/Gemfile
+++ b/examples/weather/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gem 'celluloid-io'

--- a/examples/weather/weatherbot.rb
+++ b/examples/weather/weatherbot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot'
 
 SlackRubyBot::Client.logger.level = Logger::WARN

--- a/lib/config/application.rb
+++ b/lib/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 

--- a/lib/config/boot.rb
+++ b/lib/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'logger'
 require 'active_support'

--- a/lib/config/environment.rb
+++ b/lib/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['RACK_ENV'] ||= 'development'
 
 require File.expand_path('../application', __FILE__)

--- a/lib/initializers/giphy.rb
+++ b/lib/initializers/giphy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'giphy'
 rescue LoadError

--- a/lib/slack-ruby-bot.rb
+++ b/lib/slack-ruby-bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../config/environment', __FILE__)
 
 require 'slack-ruby-bot/version'

--- a/lib/slack-ruby-bot/about.rb
+++ b/lib/slack-ruby-bot/about.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
-  ABOUT = <<-ABOUT.freeze
+  ABOUT = <<-ABOUT
     #{SlackRubyBot::VERSION}
     https://github.com/slack-ruby/slack-ruby-bot
     https://twitter.com/dblockdotorg

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   class App < Server
     def initialize(options = {})

--- a/lib/slack-ruby-bot/bot.rb
+++ b/lib/slack-ruby-bot/bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   class Bot < SlackRubyBot::Commands::Base
     delegate :client, to: :instance

--- a/lib/slack-ruby-bot/client.rb
+++ b/lib/slack-ruby-bot/client.rb
@@ -16,11 +16,11 @@ module SlackRubyBot
         self.self ? self.self.name : nil,
         aliases ? aliases.map(&:downcase) : nil,
         SlackRubyBot::Config.aliases ? SlackRubyBot::Config.aliases.map(&:downcase) : nil,
-        self.self && self.self.id ? "<@#{self.self.id.downcase}>" : nil,
+        self.self&.id ? "<@#{self.self.id.downcase}>" : nil,
         SlackRubyBot::Config.user_id ? "<@#{SlackRubyBot::Config.user_id.downcase}>" : nil,
-        self.self && self.self.id ? "<@#{self.self.id.downcase}>:" : nil,
+        self.self&.id ? "<@#{self.self.id.downcase}>:" : nil,
         SlackRubyBot::Config.user_id ? "<@#{SlackRubyBot::Config.user_id.downcase}>:" : nil,
-        self.self && self.self.name ? "#{self.self.name.downcase}:" : nil,
+        self.self&.name ? "#{self.self.name.downcase}:" : nil,
         SlackRubyBot::Config.user ? "#{SlackRubyBot::Config.user}:" : nil
       ].compact.flatten
     end
@@ -35,7 +35,7 @@ module SlackRubyBot
     end
 
     def name
-      SlackRubyBot.config.user || (self.self && self.self.name)
+      SlackRubyBot.config.user || self.self&.name
     end
 
     def url

--- a/lib/slack-ruby-bot/client.rb
+++ b/lib/slack-ruby-bot/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   class Client < Slack::RealTime::Client
     include Loggable

--- a/lib/slack-ruby-bot/client.rb
+++ b/lib/slack-ruby-bot/client.rb
@@ -56,7 +56,7 @@ module SlackRubyBot
           nil
         end
       end
-      text = [text, gif && gif.image_url.to_s].compact.join("\n")
+      text = [text, gif&.image_url.to_s].compact.join('')
       message({ text: text }.merge(options))
     end
   end

--- a/lib/slack-ruby-bot/commands.rb
+++ b/lib/slack-ruby-bot/commands.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot/commands/base'
 require 'slack-ruby-bot/commands/about'
 require 'slack-ruby-bot/commands/help'

--- a/lib/slack-ruby-bot/commands/about.rb
+++ b/lib/slack-ruby-bot/commands/about.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Commands
     class Default < Base

--- a/lib/slack-ruby-bot/commands/base.rb
+++ b/lib/slack-ruby-bot/commands/base.rb
@@ -139,7 +139,7 @@ module SlackRubyBot
         end
 
         def finalize_routes!
-          return if routes && routes.any?
+          return if routes&.any?
           command command_name_from_class
         end
 

--- a/lib/slack-ruby-bot/commands/base.rb
+++ b/lib/slack-ruby-bot/commands/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'support/match'
 require_relative 'support/help'
 

--- a/lib/slack-ruby-bot/commands/help.rb
+++ b/lib/slack-ruby-bot/commands/help.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Commands
     class Help < Base

--- a/lib/slack-ruby-bot/commands/hi.rb
+++ b/lib/slack-ruby-bot/commands/hi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Commands
     class Hi < Base

--- a/lib/slack-ruby-bot/commands/support/attrs.rb
+++ b/lib/slack-ruby-bot/commands/support/attrs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Commands
     module Support

--- a/lib/slack-ruby-bot/commands/support/help.rb
+++ b/lib/slack-ruby-bot/commands/support/help.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 require_relative 'attrs'
 

--- a/lib/slack-ruby-bot/commands/support/match.rb
+++ b/lib/slack-ruby-bot/commands/support/match.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Commands
     module Support

--- a/lib/slack-ruby-bot/commands/unknown.rb
+++ b/lib/slack-ruby-bot/commands/unknown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Commands
     class Unknown < Base

--- a/lib/slack-ruby-bot/config.rb
+++ b/lib/slack-ruby-bot/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Config
     extend self

--- a/lib/slack-ruby-bot/hooks.rb
+++ b/lib/slack-ruby-bot/hooks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot/hooks/set'
 require 'slack-ruby-bot/hooks/hello'
 require 'slack-ruby-bot/hooks/message'

--- a/lib/slack-ruby-bot/hooks/hello.rb
+++ b/lib/slack-ruby-bot/hooks/hello.rb
@@ -8,7 +8,7 @@ module SlackRubyBot
       end
 
       def call(client, _data)
-        return unless client && client.team
+        return unless client&.team
         logger.info "Successfully connected team #{client.team.name} (#{client.team.id}) to https://#{client.team.domain}.slack.com."
       end
     end

--- a/lib/slack-ruby-bot/hooks/hello.rb
+++ b/lib/slack-ruby-bot/hooks/hello.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Hooks
     class Hello

--- a/lib/slack-ruby-bot/hooks/hook_support.rb
+++ b/lib/slack-ruby-bot/hooks/hook_support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Hooks
     module HookSupport

--- a/lib/slack-ruby-bot/hooks/message.rb
+++ b/lib/slack-ruby-bot/hooks/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Hooks
     class Message

--- a/lib/slack-ruby-bot/hooks/message.rb
+++ b/lib/slack-ruby-bot/hooks/message.rb
@@ -4,7 +4,7 @@ module SlackRubyBot
       def call(client, data)
         data.text = +data.text if data.text   # Thawing data.text
         return if message_to_self_not_allowed? && message_to_self?(client, data)
-        data.text.strip! if data.text
+        data.text&.strip!
         result = child_command_classes.detect { |d| d.invoke(client, data) }
         result ||= built_in_command_classes.detect { |d| d.invoke(client, data) }
         result ||= SlackRubyBot::Commands::Unknown.tap { |d| d.invoke(client, data) }
@@ -37,7 +37,7 @@ module SlackRubyBot
       #
       def child_command_classes
         command_classes.reject do |k|
-          k.name && k.name.starts_with?('SlackRubyBot::Commands::')
+          k.name&.starts_with?('SlackRubyBot::Commands::')
         end
       end
 
@@ -48,7 +48,7 @@ module SlackRubyBot
       #
       def built_in_command_classes
         command_classes.select do |k|
-          k.name && k.name.starts_with?('SlackRubyBot::Commands::') && k != SlackRubyBot::Commands::Unknown
+          k.name&.starts_with?('SlackRubyBot::Commands::') && k != SlackRubyBot::Commands::Unknown
         end
       end
     end

--- a/lib/slack-ruby-bot/hooks/message.rb
+++ b/lib/slack-ruby-bot/hooks/message.rb
@@ -2,6 +2,7 @@ module SlackRubyBot
   module Hooks
     class Message
       def call(client, data)
+        data.text = +data.text if data.text   # Thawing data.text
         return if message_to_self_not_allowed? && message_to_self?(client, data)
         data.text.strip! if data.text
         result = child_command_classes.detect { |d| d.invoke(client, data) }

--- a/lib/slack-ruby-bot/hooks/message.rb
+++ b/lib/slack-ruby-bot/hooks/message.rb
@@ -4,7 +4,7 @@ module SlackRubyBot
   module Hooks
     class Message
       def call(client, data)
-        data.text = +data.text if data.text   # Thawing data.text
+        data.text = +data.text if data.text # Thawing data.text
         return if message_to_self_not_allowed? && message_to_self?(client, data)
         data.text&.strip!
         result = child_command_classes.detect { |d| d.invoke(client, data) }

--- a/lib/slack-ruby-bot/hooks/set.rb
+++ b/lib/slack-ruby-bot/hooks/set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Hooks
     class Set

--- a/lib/slack-ruby-bot/mvc.rb
+++ b/lib/slack-ruby-bot/mvc.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot/mvc/mvc'

--- a/lib/slack-ruby-bot/mvc/controller/base.rb
+++ b/lib/slack-ruby-bot/mvc/controller/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module MVC
     module Controller

--- a/lib/slack-ruby-bot/mvc/model/base.rb
+++ b/lib/slack-ruby-bot/mvc/model/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module MVC
     module Model

--- a/lib/slack-ruby-bot/mvc/mvc.rb
+++ b/lib/slack-ruby-bot/mvc/mvc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../mvc/controller/base'
 
 require_relative '../mvc/model/base'

--- a/lib/slack-ruby-bot/mvc/view/base.rb
+++ b/lib/slack-ruby-bot/mvc/view/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module MVC
     module View

--- a/lib/slack-ruby-bot/rspec.rb
+++ b/lib/slack-ruby-bot/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
 
 require 'rubygems'

--- a/lib/slack-ruby-bot/rspec/support/bots_for_tests.rb
+++ b/lib/slack-ruby-bot/rspec/support/bots_for_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Testing
   class WeatherBot < SlackRubyBot::Bot
     help do

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples 'a slack ruby bot' do
   context 'not configured' do
     before do

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/not_respond.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/not_respond.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/expectations'
 
 RSpec::Matchers.define :not_respond do

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_error.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/expectations'
 
 RSpec::Matchers.define :respond_with_error do |error, error_message|

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/expectations'
 RSpec::Matchers.define :respond_with_slack_message do |expected|
   include SlackRubyBot::SpecHelpers

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/respond_with_slack_messages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/expectations'
 RSpec::Matchers.define :respond_with_slack_messages do |expected|
   include SlackRubyBot::SpecHelpers

--- a/lib/slack-ruby-bot/rspec/support/slack_api_key.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack_api_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before :all do
     ENV['SLACK_API_TOKEN'] ||= 'test'

--- a/lib/slack-ruby-bot/rspec/support/slack_ruby_bot_configure.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack_ruby_bot_configure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before :each do
     SlackRubyBot.configure do |c|

--- a/lib/slack-ruby-bot/rspec/support/spec_helpers.rb
+++ b/lib/slack-ruby-bot/rspec/support/spec_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module SpecHelpers
     private

--- a/lib/slack-ruby-bot/rspec/support/vcr.rb
+++ b/lib/slack-ruby-bot/rspec/support/vcr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'vcr'
 
 VCR.configure do |config|

--- a/lib/slack-ruby-bot/server.rb
+++ b/lib/slack-ruby-bot/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   class Server
     include Loggable

--- a/lib/slack-ruby-bot/support/loggable.rb
+++ b/lib/slack-ruby-bot/support/loggable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
   module Loggable
     def self.included(base)

--- a/lib/slack-ruby-bot/version.rb
+++ b/lib/slack-ruby-bot/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlackRubyBot
-  VERSION = '0.11.1'.freeze
+  VERSION = '0.11.1'
 end

--- a/lib/slack_ruby_bot.rb
+++ b/lib/slack_ruby_bot.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot'

--- a/slack-ruby-bot.gemspec
+++ b/slack-ruby-bot.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'slack-ruby-bot/version'
 

--- a/slack-ruby-bot.gemspec
+++ b/slack-ruby-bot.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop', '0.51.0'
+  s.add_development_dependency 'rubocop', '0.52.0'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
 end

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::App do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/client_spec.rb
+++ b/spec/slack-ruby-bot/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Client do
   describe '#send_gifs?' do
     context 'without giphy is false', unless: ENV.key?('WITH_GIPHY') do

--- a/spec/slack-ruby-bot/commands/about_spec.rb
+++ b/spec/slack-ruby-bot/commands/about_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Default do
   it 'lowercase' do
     expect(message: SlackRubyBot.config.user).to respond_with_slack_message(SlackRubyBot::ABOUT)

--- a/spec/slack-ruby-bot/commands/aliases_spec.rb
+++ b/spec/slack-ruby-bot/commands/aliases_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot do
   def client
     SlackRubyBot::Client.new aliases: %w[:emoji: alias каспаров B0?.@(*^$]

--- a/spec/slack-ruby-bot/commands/attachment_spec.rb
+++ b/spec/slack-ruby-bot/commands/attachment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   context 'optional fields to scan' do
     let! :command do

--- a/spec/slack-ruby-bot/commands/bot_message_spec.rb
+++ b/spec/slack-ruby-bot/commands/bot_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Unknown do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/bot_spec.rb
+++ b/spec/slack-ruby-bot/commands/bot_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Bot do
   let! :command do
     Class.new(SlackRubyBot::Bot) do

--- a/spec/slack-ruby-bot/commands/commands_command_classes_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_command_classes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Base do
   let! :command1 do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_permitted_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_permitted_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands, 'permitted?' do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_precedence_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_precedence_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_regexp_escape_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_regexp_escape_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_regexp_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_regexp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_spaces_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_spaces_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_with_block_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_with_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/commands_with_expression_spec.rb
+++ b/spec/slack-ruby-bot/commands/commands_with_expression_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/direct_messages_spec.rb
+++ b/spec/slack-ruby-bot/commands/direct_messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/empty_text_spec.rb
+++ b/spec/slack-ruby-bot/commands/empty_text_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/help_spec.rb
+++ b/spec/slack-ruby-bot/commands/help_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Help do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/hi_spec.rb
+++ b/spec/slack-ruby-bot/commands/hi_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Hi do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/match_spec.rb
+++ b/spec/slack-ruby-bot/commands/match_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/message_loop_spec.rb
+++ b/spec/slack-ruby-bot/commands/message_loop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::App do
   def app
     SlackRubyBot::App.new

--- a/spec/slack-ruby-bot/commands/nil_message_spec.rb
+++ b/spec/slack-ruby-bot/commands/nil_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/not_implemented_spec.rb
+++ b/spec/slack-ruby-bot/commands/not_implemented_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Base do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/operators_spec.rb
+++ b/spec/slack-ruby-bot/commands/operators_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/operators_with_block_spec.rb
+++ b/spec/slack-ruby-bot/commands/operators_with_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/scan_spec.rb
+++ b/spec/slack-ruby-bot/commands/scan_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/send_gif_spec.rb
+++ b/spec/slack-ruby-bot/commands/send_gif_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands, if: ENV.key?('WITH_GIPHY') do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/send_message_spec.rb
+++ b/spec/slack-ruby-bot/commands/send_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/send_message_with_gif_spec.rb
+++ b/spec/slack-ruby-bot/commands/send_message_with_gif_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands, if: ENV.key?('WITH_GIPHY') do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/commands/support/attrs_spec.rb
+++ b/spec/slack-ruby-bot/commands/support/attrs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Support::Attrs do
   let(:help_attrs) { described_class.new('WeatherBot') }
 

--- a/spec/slack-ruby-bot/commands/support/help_spec.rb
+++ b/spec/slack-ruby-bot/commands/support/help_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Support::Help do
   let(:bot_class) { Testing::WeatherBot }
   let(:command_class) { Testing::HelloCommand }

--- a/spec/slack-ruby-bot/commands/support/match_spec.rb
+++ b/spec/slack-ruby-bot/commands/support/match_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Support::Match do
   context 'initialized with invalid args' do
     subject { -> { described_class.new('invalid-match-data') } }

--- a/spec/slack-ruby-bot/commands/unknown_spec.rb
+++ b/spec/slack-ruby-bot/commands/unknown_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Commands::Unknown do
   it 'invalid command' do
     expect(message: "#{SlackRubyBot.config.user} foobar").to respond_with_slack_message("Sorry <@user>, I don't understand that command!")

--- a/spec/slack-ruby-bot/config_spec.rb
+++ b/spec/slack-ruby-bot/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Config do
   describe '.send_gifs?' do
     after { ENV.delete 'SLACK_RUBY_BOT_SEND_GIFS' }

--- a/spec/slack-ruby-bot/hooks/hook_support_spec.rb
+++ b/spec/slack-ruby-bot/hooks/hook_support_spec.rb
@@ -47,7 +47,7 @@ describe SlackRubyBot::Hooks::HookSupport do
     subject { super().new }
     it 'delegates to `hooks.add` method' do
       event_name = :message_received
-      handler = ->(_, _) {}
+      handler = ->(_, _){}
 
       expect(subject.send(:_hooks)).to receive(:add).with(event_name, handler).and_call_original
       subject.on(event_name, handler)

--- a/spec/slack-ruby-bot/hooks/hook_support_spec.rb
+++ b/spec/slack-ruby-bot/hooks/hook_support_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Hooks::HookSupport do
   subject do
     Class.new do

--- a/spec/slack-ruby-bot/hooks/message_spec.rb
+++ b/spec/slack-ruby-bot/hooks/message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Hooks::Message do
   let(:message_hook) { described_class.new }
 

--- a/spec/slack-ruby-bot/hooks/set_spec.rb
+++ b/spec/slack-ruby-bot/hooks/set_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Hooks::Set do
   let(:client) { Slack::RealTime::Client.new }
 

--- a/spec/slack-ruby-bot/hooks/set_spec.rb
+++ b/spec/slack-ruby-bot/hooks/set_spec.rb
@@ -5,7 +5,7 @@ describe SlackRubyBot::Hooks::Set do
     subject { described_class.new(client) }
 
     it 'lets you add hook handlers' do
-      handler = ->(_, _) {}
+      handler = ->(_, _){}
 
       expect do
         subject.add(:message, handler)
@@ -16,8 +16,8 @@ describe SlackRubyBot::Hooks::Set do
     end
 
     it 'lets you add multiple handlers for the same hook' do
-      handler_1 = ->(_, _) {}
-      handler_2 = ->(_, _) {}
+      handler_1 = ->(_, _){}
+      handler_2 = ->(_, _){}
 
       expect do
         subject.add(:message, handler_1)
@@ -34,12 +34,12 @@ describe SlackRubyBot::Hooks::Set do
 
     it "doesn't barf when add callbacks prior to injecting client" do
       expect do
-        subject.add(:hook, ->(_, _) {})
+        subject.add(:hook, ->(_, _){})
       end.to_not raise_error
     end
 
     it 'triggers hooks when client is configured later' do
-      handler = ->(_, _) {}
+      handler = ->(_, _){}
 
       subject.add(:hook, handler)
 

--- a/spec/slack-ruby-bot/mvc/controller/controller_to_command_spec.rb
+++ b/spec/slack-ruby-bot/mvc/controller/controller_to_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::MVC::Controller::Base, 'initialization' do
   let(:model) { double('model') }
   let(:view) { double('view') }

--- a/spec/slack-ruby-bot/rspec/respond_with_error_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe RSpec do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/rspec/respond_with_slack_message_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_slack_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe RSpec do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/rspec/respond_with_slack_messages_spec.rb
+++ b/spec/slack-ruby-bot/rspec/respond_with_slack_messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe RSpec do
   let! :command do
     Class.new(SlackRubyBot::Commands::Base) do

--- a/spec/slack-ruby-bot/server_spec.rb
+++ b/spec/slack-ruby-bot/server_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Server do
   let(:logger) { subject.send :logger }
   let(:client) { Slack::RealTime::Client.new }

--- a/spec/slack-ruby-bot/support/loggable_spec.rb
+++ b/spec/slack-ruby-bot/support/loggable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot::Loggable do
   let!(:class_with_logger)       { Class.new SlackRubyBot::Commands::Base }
   let!(:child_class_with_logger) { Class.new class_with_logger }

--- a/spec/slack-ruby-bot/version_spec.rb
+++ b/spec/slack-ruby-bot/version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe SlackRubyBot do
   it 'has a version' do
     expect(SlackRubyBot::VERSION).to_not be nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'slack-ruby-bot/rspec'
 require 'webmock/rspec'


### PR DESCRIPTION
When I want to use this gem in Ruby 2.5.1, Rubocop issued some warnings.
So, I fixed some issues.
- Add magic comment `# frozen_string_literal: true` for all files
- Replace to safe navigation operator `&.`  from conditional expr  like ` hoge && hoge.foo`