### PR TITLE
Allow frozen string in hooks message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.11.2 (Next)
 
 * [#198](https://github.com/slack-ruby/slack-ruby-bot/pull/198): Recommend using `async-websocket` instead of `celluloid-io` - [@dblock](https://github.com/dblock).
+* [#202](https://github.com/slack-ruby/slack-ruby-bot/pull/202): Allow frozen string in Hooks::Message - [@jonosenior](https://github.com/jonosenior).
 * Your contribution here.
 
 ### 0.11.1 (05/06/2018)

--- a/lib/slack-ruby-bot/hooks/message.rb
+++ b/lib/slack-ruby-bot/hooks/message.rb
@@ -3,7 +3,7 @@ module SlackRubyBot
     class Message
       def call(client, data)
         return if message_to_self_not_allowed? && message_to_self?(client, data)
-        data.text.strip! if data.text
+        data.text = data.text.strip if data.text
         result = child_command_classes.detect { |d| d.invoke(client, data) }
         result ||= built_in_command_classes.detect { |d| d.invoke(client, data) }
         result ||= SlackRubyBot::Commands::Unknown.tap { |d| d.invoke(client, data) }

--- a/spec/slack-ruby-bot/hooks/message_spec.rb
+++ b/spec/slack-ruby-bot/hooks/message_spec.rb
@@ -1,6 +1,15 @@
 describe SlackRubyBot::Hooks::Message do
   let(:message_hook) { described_class.new }
 
+  describe '#call' do
+    it 'doesn\'t raise an error when message is a frozen string' do
+      message_hook.call(
+        SlackRubyBot::Client.new,
+        Hashie::Mash.new(text: 'message'.freeze)
+      )
+    end
+  end
+
   describe '#child_command_classes' do
     it 'returns only child command classes' do
       child_command_classes = message_hook.send(:child_command_classes)


### PR DESCRIPTION
In our code we currently use `frozen_string_literal: true`. This causes an error because the slack-ruby-bot is trying to mutate a string.

We only fixed and created a test for the example we found, but there might be more. 

Would you be open to using frozen_string_literal by default? I would be open to do that if you want. 