### PR TITLE
Removing restart logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#198](https://github.com/slack-ruby/slack-ruby-bot/pull/198): Recommend using `async-websocket` instead of `celluloid-io` - [@dblock](https://github.com/dblock).
 * [#202](https://github.com/slack-ruby/slack-ruby-bot/pull/202): Allow frozen string in Hooks::Message - [@jonosenior](https://github.com/jonosenior).
+* * [#203](https://github.com/slack-ruby/slack-ruby-bot/pull/203): Removing restart logic - [@RodneyU215](https://github.com/RodneyU215).
 * Your contribution here.
 
 ### 0.11.1 (05/06/2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-### 0.11.2 (Next)
+### 0.12.0 (Next)
 
 * [#198](https://github.com/slack-ruby/slack-ruby-bot/pull/198): Recommend using `async-websocket` instead of `celluloid-io` - [@dblock](https://github.com/dblock).
 * [#202](https://github.com/slack-ruby/slack-ruby-bot/pull/202): Allow frozen string in Hooks::Message - [@jonosenior](https://github.com/jonosenior).
-* * [#203](https://github.com/slack-ruby/slack-ruby-bot/pull/203): Removing restart logic - [@RodneyU215](https://github.com/RodneyU215).
+* [#203](https://github.com/slack-ruby/slack-ruby-bot/pull/203): Removing restart logic - [@RodneyU215](https://github.com/RodneyU215).
 * Your contribution here.
 
 ### 0.11.1 (05/06/2018)

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'http://rubygems.org'
 
 gemspec
 
+gem 'slack-ruby-client', github: 'slack-ruby/slack-ruby-client', branch: 'master'
+
 gem ENV['CONCURRENCY'], require: false if ENV.key?('CONCURRENCY')
 
 # rubocop:enable Bundler/OrderedGems

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,7 +5,7 @@ Upgrading SlackRubyBot
 
 #### Remove any references to `SlackRubyBot::Server#restart!`
 
-We have deprecated `SlackRubyBot::Server#restart!` since the [`slack-ruby-client`](https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md) now restarts any connection that was not intentionally stopped via `SlackRubyBot::Server#stop!`.
+We have removed `SlackRubyBot::Server#restart!` since the [`slack-ruby-client`](https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md) now restarts any connection that was not intentionally stopped via `SlackRubyBot::Server#stop!`.
 
 ### Upgrading to >= 0.10.4
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,12 @@
 Upgrading SlackRubyBot
 ======================
 
+### Upgrading to >= 0.12.0
+
+#### Remove any references to `SlackRubyBot::Server#restart!`
+
+We have deprecated `SlackRubyBot::Server#restart!` since the [`slack-ruby-client`](https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md) now restarts any connection that was not intentionally stopped via `SlackRubyBot::Server#stop!`.
+
 ### Upgrading to >= 0.10.4
 
 #### Replace `server.hooks.add` with `server.on`

--- a/lib/slack-ruby-bot/server.rb
+++ b/lib/slack-ruby-bot/server.rb
@@ -32,19 +32,14 @@ module SlackRubyBot
     end
 
     def start!
-      @stopping = false
-      @async = false
       client.start!
     end
 
     def start_async
-      @stopping = false
-      @async = true
       client.start_async
     end
 
     def stop!
-      @stopping = true
       client.stop! if @client
     end
 

--- a/lib/slack-ruby-bot/server.rb
+++ b/lib/slack-ruby-bot/server.rb
@@ -48,21 +48,6 @@ module SlackRubyBot
       client.stop! if @client
     end
 
-    def restart!(wait = 1)
-      @async ? start_async : start!
-    rescue StandardError => e
-      case e.message
-      when 'account_inactive', 'invalid_auth'
-        logger.error "#{token}: #{e.message}, team will be deactivated."
-        @stopping = true
-      else
-        sleep wait
-        logger.error "#{e.message}, reconnecting in #{wait} second(s)."
-        logger.debug e
-        restart! [wait * 2, 60].min
-      end
-    end
-
     private
 
     def handle_exceptions
@@ -98,10 +83,6 @@ module SlackRubyBot
     def client
       @client ||= begin
         client = SlackRubyBot::Client.new(aliases: aliases, send_gifs: send_gifs, token: token)
-        client.on :close do |_data|
-          @client = nil
-          restart! unless @stopping
-        end
         _hooks.client = client
 
         client

--- a/lib/slack-ruby-bot/version.rb
+++ b/lib/slack-ruby-bot/version.rb
@@ -1,3 +1,3 @@
 module SlackRubyBot
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.11.2'.freeze
 end

--- a/lib/slack-ruby-bot/version.rb
+++ b/lib/slack-ruby-bot/version.rb
@@ -1,3 +1,3 @@
 module SlackRubyBot
-  VERSION = '0.11.2'.freeze
+  VERSION = '0.12.0'.freeze
 end

--- a/slack-ruby-bot.gemspec
+++ b/slack-ruby-bot.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'The easiest way to write a Slack bot in Ruby.'
   s.add_dependency 'hashie'
-  s.add_dependency 'slack-ruby-client', git: "git@github.com:slack-ruby/slack-ruby-client.git"
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/slack-ruby-bot.gemspec
+++ b/slack-ruby-bot.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'The easiest way to write a Slack bot in Ruby.'
   s.add_dependency 'hashie'
-  s.add_dependency 'slack-ruby-client', '>= 0.13.2'
+  s.add_dependency 'slack-ruby-client', git: "git@github.com:slack-ruby/slack-ruby-client.git"
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/slack-ruby-bot.gemspec
+++ b/slack-ruby-bot.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'The easiest way to write a Slack bot in Ruby.'
   s.add_dependency 'hashie'
-  s.add_dependency 'slack-ruby-client', '>= 0.6.0'
+  s.add_dependency 'slack-ruby-client', '>= 0.13.2'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/spec/slack-ruby-bot/server_spec.rb
+++ b/spec/slack-ruby-bot/server_spec.rb
@@ -94,21 +94,4 @@ describe SlackRubyBot::Server do
       end
     end
   end
-  context '#restart!' do
-    subject do
-      SlackRubyBot::Server.new(token: 'token')
-    end
-    it 'reloads server after disconnection' do
-      expect(subject).to receive(:restart!)
-      subject.send(:client).send(:callbacks)['close'].first.call
-      expect(subject.instance_variable_get(:@stopping)).to be_falsy
-    end
-    it 'does not reload server for inactive account' do
-      stopping = -> { subject.instance_variable_get :@stopping }
-      allow(subject).to receive(:start!) { raise StandardError, 'account_inactive' }
-      expect(stopping.call).to be_falsy
-      subject.restart!
-      expect(stopping.call).to be true
-    end
-  end
 end


### PR DESCRIPTION
### Summary
1. The method `#restart!` has been removed from `SlackRubyBot::Server`. It was causing issues with the restart logic that was recently added to [`slack-ruby-client`](https://github.com/slack-ruby/slack-ruby-client/pull/226). 

### Requirements
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slack-ruby/slack-ruby-bot/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.