### PR TITLE
Suggest async-websocket instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [CHANGELOG](CHANGELOG.md) for a history of changes and [UPGRADING](UPGRADING
 source 'https://rubygems.org'
 
 gem 'slack-ruby-bot'
-gem 'celluloid-io'
+gem 'async-websocket'
 ```
 
 #### pongbot.rb


### PR DESCRIPTION
I was running into problems with logging due to the fact that celluloid was not handling UTF-8 byte order mask (or something equivalent coming from Slack messages), it was just plain crashing when I tried to send data to a log provider. 

I found out that celluloid is not maintained anymore and it's [up for grabs](https://github.com/celluloid/celluloid/issues/779). 

Once I checked the cousin repo https://github.com/slack-ruby/slack-ruby-client#installation I noticed that 4 adapters are supported but the one `async-websocket` is the one recommended.