### PR TITLE
Fix symbol for reaction view example

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ class MyView < SlackRubyBot::MVC::View::Base
 
   def react_thumbsup
     client.web_client.reactions_add(
-      name: :thumbs_up,
+      name: :thumbsup,
       channel: data.channel,
       timestamp: data.ts,
       as_user: true)
@@ -634,7 +634,7 @@ class MyView < SlackRubyBot::MVC::View::Base
 
   def react_thumbsdown
     client.web_client.reactions_remove(
-      name: :thumbs_up,
+      name: :thumbsup,
       channel: data.channel,
       timestamp: data.ts,
       as_user: true)


### PR DESCRIPTION
The README has an example of using the reaction API of adding a :+1: , but the symbol has an underscore which blows up when you cut'n'paste it into your own code.