### PR TITLE
update description for installing async-websocket gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [CHANGELOG](CHANGELOG.md) for a history of changes and [UPGRADING](UPGRADING
 source 'https://rubygems.org'
 
 gem 'slack-ruby-bot'
-gem 'async-websocket'
+gem 'async-websocket', '~>0.8.0'
 ```
 
 #### pongbot.rb


### PR DESCRIPTION
realted:
https://github.com/slack-ruby/slack-ruby-bot/issues/222
https://github.com/slack-ruby/slack-ruby-client/pull/268

By breaking change in async-websocket `v0.9`, `Bot.run` occurs errors.
To avoid this error, I updated dependency installation description of Gemfile in README.md.