### PR TITLE
Missing bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ class Market < SlackRubyBot::Bot
   command 'help' do |client, data, match|
     user_command = match[:expression]
     help_attrs = SlackRubyBot::Commands::Support::Help.instance.find_command_help_attrs(user_command)
-    client.say(channel: data.channel, text: "#{help_attrs.command_desc}\n\n#{help_attrs.command_long_desc}"
+    client.say(channel: data.channel, text: "#{help_attrs.command_desc}\n\n#{help_attrs.command_long_desc}")
   end
 end
 ```


### PR DESCRIPTION
The example was missing a bracket.