### PR TITLE
Use config.token and config.aliases if set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.14.1 (Next)
 
 * Your contribution here.
-* [#254](https://github.com/slack-ruby/slack-ruby-bot/pull/254): Allow setting of `config.token` in initializer - [@wasabigeek](https://github.com/wasabigeek).
+* [#254](https://github.com/slack-ruby/slack-ruby-bot/pull/254): Allow setting of `config.token` and `config.aliases` in initializer - [@wasabigeek](https://github.com/wasabigeek).
 * [#253](https://github.com/slack-ruby/slack-ruby-bot/pull/253): Remove reference to unsupported Giphy content rating - [@wasabigeek](https://github.com/wasabigeek).
 
 ### 0.14.0 (2020/4/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.14.1 (Next)
 
 * Your contribution here.
-* [#254](https://github.com/slack-ruby/slack-ruby-bot/pull/254): Allow setting of config.token in initializer - [@wasabigeek](https://github.com/wasabigeek).
+* [#254](https://github.com/slack-ruby/slack-ruby-bot/pull/254): Allow setting of `config.token` in initializer - [@wasabigeek](https://github.com/wasabigeek).
 * [#253](https://github.com/slack-ruby/slack-ruby-bot/pull/253): Remove reference to unsupported Giphy content rating - [@wasabigeek](https://github.com/wasabigeek).
 
 ### 0.14.0 (2020/4/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.14.1 (Next)
 
 * Your contribution here.
+* [#254](https://github.com/slack-ruby/slack-ruby-bot/pull/254): Allow setting of config.token in initializer - [@wasabigeek](https://github.com/wasabigeek).
 * [#253](https://github.com/slack-ruby/slack-ruby-bot/pull/253): Remove reference to unsupported Giphy content rating - [@wasabigeek](https://github.com/wasabigeek).
 
 ### 0.14.0 (2020/4/2)

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -22,7 +22,7 @@ module SlackRubyBot
 
     def self.configure!
       SlackRubyBot.configure do |config|
-        config.token ||= ENV['SLACK_API_TOKEN']
+        config.token = ENV['SLACK_API_TOKEN'] if ENV.key?('SLACK_API_TOKEN')
         raise("Missing ENV['SLACK_API_TOKEN'].") if config.token.nil?
 
         config.aliases = ENV['SLACK_RUBY_BOT_ALIASES'].split(' ') if ENV['SLACK_RUBY_BOT_ALIASES']

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -3,7 +3,7 @@
 module SlackRubyBot
   class App < Server
     def initialize(options = {})
-      server_options = options.select { |k, _| k.to_sym == :token }
+      server_options = { token: options[:token] }
       super(server_options)
     end
 

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -18,8 +18,6 @@ module SlackRubyBot
       end
     end
 
-    private
-
     def self.configure!
       SlackRubyBot.configure do |config|
         config.token = ENV['SLACK_API_TOKEN'] if ENV.key?('SLACK_API_TOKEN')
@@ -31,7 +29,8 @@ module SlackRubyBot
         config.token = SlackRubyBot.config.token
       end
     end
-    private_class_method :configure!
+
+    private
 
     def hello(client, _data)
       if client.team && client.self

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -23,7 +23,7 @@ module SlackRubyBot
         config.token = ENV['SLACK_API_TOKEN'] if ENV.key?('SLACK_API_TOKEN')
         raise('Missing Slack API Token.') unless config.token.present?
 
-        config.aliases = ENV['SLACK_RUBY_BOT_ALIASES'].split(' ') if ENV['SLACK_RUBY_BOT_ALIASES']
+        config.aliases = ENV['SLACK_RUBY_BOT_ALIASES'].split(' ') if ENV.key?('SLACK_RUBY_BOT_ALIASES')
       end
       Slack.configure do |config|
         config.token = SlackRubyBot.config.token

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -23,7 +23,7 @@ module SlackRubyBot
     def self.configure!
       SlackRubyBot.configure do |config|
         config.token = ENV['SLACK_API_TOKEN'] if ENV.key?('SLACK_API_TOKEN')
-        raise("Missing ENV['SLACK_API_TOKEN'].") if config.token.nil?
+        raise('Missing Slack API Token.') if config.token.nil?
 
         config.aliases = ENV['SLACK_RUBY_BOT_ALIASES'].split(' ') if ENV['SLACK_RUBY_BOT_ALIASES']
       end

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -21,7 +21,7 @@ module SlackRubyBot
     def self.configure!
       SlackRubyBot.configure do |config|
         config.token = ENV['SLACK_API_TOKEN'] if ENV.key?('SLACK_API_TOKEN')
-        raise('Missing Slack API Token.') if config.token.nil?
+        raise('Missing Slack API Token.') unless config.token.present?
 
         config.aliases = ENV['SLACK_RUBY_BOT_ALIASES'].split(' ') if ENV['SLACK_RUBY_BOT_ALIASES']
       end

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -2,11 +2,6 @@
 
 module SlackRubyBot
   class App < Server
-    def initialize(options = {})
-      server_options = { token: options[:token] }
-      super(server_options)
-    end
-
     def config
       SlackRubyBot.config
     end

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -3,6 +3,23 @@
 module SlackRubyBot
   class App < Server
     def initialize(options = {})
+      super
+    end
+
+    def config
+      SlackRubyBot.config
+    end
+
+    def self.instance
+      @instance ||= begin
+        configure!
+        new
+      end
+    end
+
+    private
+
+    def self.configure!
       SlackRubyBot.configure do |config|
         config.token ||= ENV['SLACK_API_TOKEN']
         raise("Missing ENV['SLACK_API_TOKEN'].") if config.token.nil?
@@ -12,18 +29,8 @@ module SlackRubyBot
       Slack.configure do |config|
         config.token = SlackRubyBot.config.token
       end
-      super
     end
-
-    def config
-      SlackRubyBot.config
-    end
-
-    def self.instance
-      @instance ||= new
-    end
-
-    private
+    private_class_method :configure!
 
     def hello(client, _data)
       if client.team && client.self

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -4,7 +4,9 @@ module SlackRubyBot
   class App < Server
     def initialize(options = {})
       SlackRubyBot.configure do |config|
-        config.token = ENV['SLACK_API_TOKEN'] || raise("Missing ENV['SLACK_API_TOKEN'].")
+        config.token ||= ENV['SLACK_API_TOKEN']
+        raise("Missing ENV['SLACK_API_TOKEN'].") if config.token.nil?
+
         config.aliases = ENV['SLACK_RUBY_BOT_ALIASES'].split(' ') if ENV['SLACK_RUBY_BOT_ALIASES']
       end
       Slack.configure do |config|

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -3,7 +3,8 @@
 module SlackRubyBot
   class App < Server
     def initialize(options = {})
-      super
+      server_options = options.select { |k, _| k.to_sym == :token }
+      super(server_options)
     end
 
     def config
@@ -13,7 +14,7 @@ module SlackRubyBot
     def self.instance
       @instance ||= begin
         configure!
-        new
+        new(token: SlackRubyBot.config.token)
       end
     end
 

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
@@ -19,6 +19,7 @@ shared_examples 'a slack ruby bot' do
   context 'when SLACK_API_TOKEN is defined in ENV but not config' do
     it 'sets config.token from ENV' do
       allow(ENV).to receive(:[]).and_call_original.at_least(:once)
+      allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(true)
       allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
       SlackRubyBot.configure { |config| config.token = nil }
 
@@ -28,8 +29,7 @@ shared_examples 'a slack ruby bot' do
 
   context 'when SLACK_API_TOKEN is not defined in ENV but is defined in config' do
     it 'sets config.token from config' do
-      allow(ENV).to receive(:[]).at_least(:once)
-      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
+      allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(false)
       SlackRubyBot.configure { |config| config.token = token }
 
       expect(described_class.instance.config.token).to eq(token)
@@ -39,7 +39,8 @@ shared_examples 'a slack ruby bot' do
   context 'when SLACK_API_TOKEN is defined in ENV and config' do
     it 'sets config.token from config' do
       token2 = 'another-api-token'
-      allow(ENV).to receive(:[]).at_least(:once)
+      allow(ENV).to receive(:[]).and_call_original.at_least(:once)
+      allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(true)
       allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token2)
       SlackRubyBot.configure { |config| config.token = token }
 

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
@@ -12,7 +12,7 @@ shared_examples 'a slack ruby bot' do
       ENV['SLACK_API_TOKEN'] = @slack_api_token
     end
     it 'requires SLACK_API_TOKEN' do
-      expect { described_class.instance }.to raise_error RuntimeError, "Missing ENV['SLACK_API_TOKEN']."
+      expect { described_class.instance }.to raise_error RuntimeError, 'Missing Slack API Token.'
     end
   end
 

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
@@ -12,7 +12,7 @@ shared_examples 'a slack ruby bot' do
       ENV['SLACK_API_TOKEN'] = @slack_api_token
     end
     it 'requires SLACK_API_TOKEN' do
-      expect { subject }.to raise_error RuntimeError, "Missing ENV['SLACK_API_TOKEN']."
+      expect { described_class.instance }.to raise_error RuntimeError, "Missing ENV['SLACK_API_TOKEN']."
     end
   end
 
@@ -22,7 +22,7 @@ shared_examples 'a slack ruby bot' do
       allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
       SlackRubyBot.configure { |config| config.token = nil }
 
-      expect(app.config.token).to eq(token)
+      expect(described_class.instance.config.token).to eq(token)
     end
   end
 
@@ -32,7 +32,7 @@ shared_examples 'a slack ruby bot' do
       allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
       SlackRubyBot.configure { |config| config.token = token }
 
-      expect(app.config.token).to eq(token)
+      expect(described_class.instance.config.token).to eq(token)
     end
   end
 
@@ -43,7 +43,7 @@ shared_examples 'a slack ruby bot' do
       allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token2)
       SlackRubyBot.configure { |config| config.token = token }
 
-      expect(app.config.token).to eq(token)
+      expect(described_class.instance.config.token).to eq(token)
     end
   end
 end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
@@ -46,14 +46,4 @@ shared_examples 'a slack ruby bot' do
       expect(app.config.token).to eq(token)
     end
   end
-
-  context 'when SLACK_API_TOKEN is not defined in ENV or config' do
-    it 'raises error' do
-      allow(ENV).to receive(:[]).at_least(:once)
-      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
-      SlackRubyBot.configure { |config| config.token = nil }
-
-      expect { app }.to raise_error("Missing ENV['SLACK_API_TOKEN'].")
-    end
-  end
 end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
@@ -4,6 +4,7 @@ shared_examples 'a slack ruby bot' do
   context 'not configured' do
     before do
       @slack_api_token = ENV.delete('SLACK_API_TOKEN')
+      SlackRubyBot.configure { |config| config.token = nil }
     end
     after do
       ENV['SLACK_API_TOKEN'] = @slack_api_token

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 shared_examples 'a slack ruby bot' do
+  let(:token) { 'slack-api-token' }
+
   context 'not configured' do
     before do
       @slack_api_token = ENV.delete('SLACK_API_TOKEN')
@@ -11,6 +13,47 @@ shared_examples 'a slack ruby bot' do
     end
     it 'requires SLACK_API_TOKEN' do
       expect { subject }.to raise_error RuntimeError, "Missing ENV['SLACK_API_TOKEN']."
+    end
+  end
+
+  context 'when SLACK_API_TOKEN is defined in ENV but not config' do
+    it 'sets config.token from ENV' do
+      allow(ENV).to receive(:[]).and_call_original.at_least(:once)
+      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
+      SlackRubyBot.configure { |config| config.token = nil }
+
+      expect(app.config.token).to eq(token)
+    end
+  end
+
+  context 'when SLACK_API_TOKEN is not defined in ENV but is defined in config' do
+    it 'sets config.token from config' do
+      allow(ENV).to receive(:[]).at_least(:once)
+      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
+      SlackRubyBot.configure { |config| config.token = token }
+
+      expect(app.config.token).to eq(token)
+    end
+  end
+
+  context 'when SLACK_API_TOKEN is defined in ENV and config' do
+    it 'sets config.token from config' do
+      token2 = 'another-api-token'
+      allow(ENV).to receive(:[]).at_least(:once)
+      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token2)
+      SlackRubyBot.configure { |config| config.token = token }
+
+      expect(app.config.token).to eq(token)
+    end
+  end
+
+  context 'when SLACK_API_TOKEN is not defined in ENV or config' do
+    it 'raises error' do
+      allow(ENV).to receive(:[]).at_least(:once)
+      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
+      SlackRubyBot.configure { |config| config.token = nil }
+
+      expect { app }.to raise_error("Missing ENV['SLACK_API_TOKEN'].")
     end
   end
 end

--- a/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack-ruby-bot/it_behaves_like_a_slack_bot.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples 'a slack ruby bot' do
-  let(:token) { 'slack-api-token' }
-
   context 'not configured' do
     before do
       @slack_api_token = ENV.delete('SLACK_API_TOKEN')
@@ -13,38 +11,6 @@ shared_examples 'a slack ruby bot' do
     end
     it 'requires SLACK_API_TOKEN' do
       expect { described_class.instance }.to raise_error RuntimeError, 'Missing Slack API Token.'
-    end
-  end
-
-  context 'when SLACK_API_TOKEN is defined in ENV but not config' do
-    it 'sets config.token from ENV' do
-      allow(ENV).to receive(:[]).and_call_original.at_least(:once)
-      allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(true)
-      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
-      SlackRubyBot.configure { |config| config.token = nil }
-
-      expect(described_class.instance.config.token).to eq(token)
-    end
-  end
-
-  context 'when SLACK_API_TOKEN is not defined in ENV but is defined in config' do
-    it 'sets config.token from config' do
-      allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(false)
-      SlackRubyBot.configure { |config| config.token = token }
-
-      expect(described_class.instance.config.token).to eq(token)
-    end
-  end
-
-  context 'when SLACK_API_TOKEN is defined in ENV and config' do
-    it 'sets config.token from config' do
-      token2 = 'another-api-token'
-      allow(ENV).to receive(:[]).and_call_original.at_least(:once)
-      allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(true)
-      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token2)
-      SlackRubyBot.configure { |config| config.token = token }
-
-      expect(described_class.instance.config.token).to eq(token)
     end
   end
 end

--- a/lib/slack-ruby-bot/rspec/support/slack_api_key.rb
+++ b/lib/slack-ruby-bot/rspec/support/slack_api_key.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.before :all do
+  config.before :each do
     ENV['SLACK_API_TOKEN'] ||= 'test'
   end
 end

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -6,51 +6,6 @@ describe SlackRubyBot::App do
   end
   it_behaves_like 'a slack ruby bot'
 
-  describe '.initialize' do
-    let(:token) { 'slack-api-token' }
-
-    context 'when SLACK_API_TOKEN is defined in ENV but not config' do
-      it 'sets config.token from ENV' do
-        allow(ENV).to receive(:[]).and_call_original.at_least(:once)
-        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
-        SlackRubyBot.configure { |config| config.token = nil }
-
-        expect(app.config.token).to eq(token)
-      end
-    end
-
-    context 'when SLACK_API_TOKEN is not defined in ENV but is defined in config' do
-      it 'sets config.token from config' do
-        allow(ENV).to receive(:[]).at_least(:once)
-        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
-        SlackRubyBot.configure { |config| config.token = token }
-
-        expect(app.config.token).to eq(token)
-      end
-    end
-
-    context 'when SLACK_API_TOKEN is defined in ENV and config' do
-      it 'sets config.token from config' do
-        token2 = 'another-api-token'
-        allow(ENV).to receive(:[]).at_least(:once)
-        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token2)
-        SlackRubyBot.configure { |config| config.token = token }
-
-        expect(app.config.token).to eq(token)
-      end
-    end
-
-    context 'when SLACK_API_TOKEN is not defined in ENV or config' do
-      it 'raises error' do
-        allow(ENV).to receive(:[]).at_least(:once)
-        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
-        SlackRubyBot.configure { |config| config.token = nil }
-
-        expect { app }.to raise_error("Missing ENV['SLACK_API_TOKEN'].")
-      end
-    end
-  end
-
   describe '.instance' do
     it 'creates an instance of the App subclass' do
       klass = Class.new(SlackRubyBot::App)

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -14,7 +14,11 @@ describe SlackRubyBot::App do
       expect(klass.instance.class).to be klass
     end
 
-    context 'when SLACK_API_TOKEN is not defined' do
+    it 'sets config.token from ENV' do
+      expect(klass.instance.config.token).to eq('test')
+    end
+
+    context 'when token is not defined' do
       before do
         ENV.delete('SLACK_API_TOKEN')
         SlackRubyBot::Config.token = nil
@@ -25,7 +29,7 @@ describe SlackRubyBot::App do
       end
     end
 
-    context 'when SLACK_API_TOKEN is defined in ENV but not config' do
+    context 'when token is defined in ENV but not config' do
       before do
         SlackRubyBot::Config.token = nil
       end
@@ -35,7 +39,7 @@ describe SlackRubyBot::App do
       end
     end
 
-    context 'when SLACK_API_TOKEN is not defined in ENV but is defined in config' do
+    context 'when token is not defined in ENV but is defined in config' do
       before do
         ENV.delete('SLACK_API_TOKEN')
       end
@@ -45,22 +49,27 @@ describe SlackRubyBot::App do
       end
     end
 
-    context 'when SLACK_API_TOKEN is defined in ENV and config' do
-      it 'sets config.token from ENV' do
-        expect(klass.instance.config.token).to eq('test')
+    context 'when aliases are defined in config only' do
+      let(:aliases) { %w[alias alias2] }
+      before do
+        SlackRubyBot::Config.aliases = aliases
+      end
+
+      it 'sets config.aliases' do
+        expect(klass.instance.config.aliases).to eq(aliases)
       end
     end
 
-    context 'when SLACK_RUBY_BOT_ALIASES is defined in ENV' do
+    context 'when aliases are defined in ENV only' do
       before do
-        ENV['SLACK_RUBY_BOT_ALIASES'] = 'alias alias2'
+        ENV['SLACK_RUBY_BOT_ALIASES'] = 'alias3 alias4'
       end
       after do
         ENV.delete('SLACK_RUBY_BOT_ALIASES')
       end
 
-      it 'sets config.aliases' do
-        expect(klass.instance.config.aliases).to eq(%w[alias alias2])
+      it 'sets config.aliases from env' do
+        expect(klass.instance.config.aliases).to eq(%w[alias3 alias4])
       end
     end
   end

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -7,15 +7,54 @@ describe SlackRubyBot::App do
   it_behaves_like 'a slack ruby bot'
 
   describe '.instance' do
+    let(:token) { 'slack-api-token' }
+    let(:klass) { Class.new(SlackRubyBot::App) }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original.at_least(:once)
+    end
+
     it 'creates an instance of the App subclass' do
-      klass = Class.new(SlackRubyBot::App)
       expect(klass.instance.class).to be klass
     end
 
-    it 'sets the token' do
-      token = 'slack-api-token'
-      SlackRubyBot.configure { |config| config.token = token }
-      expect(described_class.instance.token).to eq(token)
+    context 'when SLACK_API_TOKEN is not defined' do
+      it 'raises error' do
+        allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(false)
+        SlackRubyBot.configure { |config| config.token = nil }
+
+        expect { klass.instance }.to raise_error RuntimeError, 'Missing Slack API Token.'
+      end
+    end
+
+    context 'when SLACK_API_TOKEN is defined in ENV but not config' do
+      it 'sets config.token from ENV' do
+        allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(true)
+        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
+        SlackRubyBot.configure { |config| config.token = nil }
+
+        expect(klass.instance.config.token).to eq(token)
+      end
+    end
+
+    context 'when SLACK_API_TOKEN is not defined in ENV but is defined in config' do
+      it 'sets config.token from config' do
+        allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(false)
+        SlackRubyBot.configure { |config| config.token = token }
+
+        expect(klass.instance.config.token).to eq(token)
+      end
+    end
+
+    context 'when SLACK_API_TOKEN is defined in ENV and config' do
+      it 'sets config.token from ENV' do
+        token2 = 'another-api-token'
+        allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(true)
+        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token2)
+        SlackRubyBot.configure { |config| config.token = token }
+
+        expect(klass.instance.config.token).to eq(token2)
+      end
     end
   end
 

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -10,50 +10,44 @@ describe SlackRubyBot::App do
     let(:token) { 'slack-api-token' }
     let(:klass) { Class.new(SlackRubyBot::App) }
 
-    before do
-      allow(ENV).to receive(:[]).and_call_original.at_least(:once)
-    end
-
     it 'creates an instance of the App subclass' do
       expect(klass.instance.class).to be klass
     end
 
     context 'when SLACK_API_TOKEN is not defined' do
-      it 'raises error' do
-        allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(false)
-        SlackRubyBot.configure { |config| config.token = nil }
+      before do
+        ENV.delete('SLACK_API_TOKEN')
+        SlackRubyBot::Config.token = nil
+      end
 
+      it 'raises error' do
         expect { klass.instance }.to raise_error RuntimeError, 'Missing Slack API Token.'
       end
     end
 
     context 'when SLACK_API_TOKEN is defined in ENV but not config' do
-      it 'sets config.token from ENV' do
-        allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(true)
-        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
-        SlackRubyBot.configure { |config| config.token = nil }
+      before do
+        SlackRubyBot::Config.token = nil
+      end
 
-        expect(klass.instance.config.token).to eq(token)
+      it 'sets config.token from ENV' do
+        expect(klass.instance.config.token).to eq('test')
       end
     end
 
     context 'when SLACK_API_TOKEN is not defined in ENV but is defined in config' do
-      it 'sets config.token from config' do
-        allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(false)
-        SlackRubyBot.configure { |config| config.token = token }
+      before do
+        ENV.delete('SLACK_API_TOKEN')
+      end
 
-        expect(klass.instance.config.token).to eq(token)
+      it 'sets config.token from config' do
+        expect(klass.instance.config.token).to eq('testtoken')
       end
     end
 
     context 'when SLACK_API_TOKEN is defined in ENV and config' do
       it 'sets config.token from ENV' do
-        token2 = 'another-api-token'
-        allow(ENV).to receive(:key?).with('SLACK_API_TOKEN').and_return(true)
-        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token2)
-        SlackRubyBot.configure { |config| config.token = token }
-
-        expect(klass.instance.config.token).to eq(token2)
+        expect(klass.instance.config.token).to eq('test')
       end
     end
   end

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -6,6 +6,26 @@ describe SlackRubyBot::App do
   end
   it_behaves_like 'a slack ruby bot'
 
+  describe '.initialize' do
+    let(:token) { 'slack-api-token' }
+
+    it 'sets config.token' do
+      allow(ENV).to receive(:[]).and_call_original.at_least(:once)
+      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
+
+      expect(app.config.token).to eq(token)
+    end
+
+    context 'when SLACK_API_TOKEN is not defined in ENV' do
+      it 'raises error' do
+        allow(ENV).to receive(:[]).at_least(:once)
+        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
+
+        expect { app }.to raise_error("Missing ENV['SLACK_API_TOKEN'].")
+      end
+    end
+  end
+
   describe '.instance' do
     it 'creates an instance of the App subclass' do
       klass = Class.new(SlackRubyBot::App)

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -50,6 +50,19 @@ describe SlackRubyBot::App do
         expect(klass.instance.config.token).to eq('test')
       end
     end
+
+    context 'when SLACK_RUBY_BOT_ALIASES is defined in ENV' do
+      before do
+        ENV['SLACK_RUBY_BOT_ALIASES'] = 'alias alias2'
+      end
+      after do
+        ENV.delete('SLACK_RUBY_BOT_ALIASES')
+      end
+
+      it 'sets config.aliases' do
+        expect(klass.instance.config.aliases).to eq(%w[alias alias2])
+      end
+    end
   end
 
   describe 'executable' do

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -9,17 +9,42 @@ describe SlackRubyBot::App do
   describe '.initialize' do
     let(:token) { 'slack-api-token' }
 
-    it 'sets config.token' do
-      allow(ENV).to receive(:[]).and_call_original.at_least(:once)
-      allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
+    context 'when SLACK_API_TOKEN is defined in ENV but not config' do
+      it 'sets config.token from ENV' do
+        allow(ENV).to receive(:[]).and_call_original.at_least(:once)
+        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token)
+        SlackRubyBot.configure { |config| config.token = nil }
 
-      expect(app.config.token).to eq(token)
+        expect(app.config.token).to eq(token)
+      end
     end
 
-    context 'when SLACK_API_TOKEN is not defined in ENV' do
+    context 'when SLACK_API_TOKEN is not defined in ENV but is defined in config' do
+      it 'sets config.token from config' do
+        allow(ENV).to receive(:[]).at_least(:once)
+        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
+        SlackRubyBot.configure { |config| config.token = token }
+
+        expect(app.config.token).to eq(token)
+      end
+    end
+
+    context 'when SLACK_API_TOKEN is defined in ENV and config' do
+      it 'sets config.token from config' do
+        token2 = 'another-api-token'
+        allow(ENV).to receive(:[]).at_least(:once)
+        allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(token2)
+        SlackRubyBot.configure { |config| config.token = token }
+
+        expect(app.config.token).to eq(token)
+      end
+    end
+
+    context 'when SLACK_API_TOKEN is not defined in ENV or config' do
       it 'raises error' do
         allow(ENV).to receive(:[]).at_least(:once)
         allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil)
+        SlackRubyBot.configure { |config| config.token = nil }
 
         expect { app }.to raise_error("Missing ENV['SLACK_API_TOKEN'].")
       end

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -11,6 +11,12 @@ describe SlackRubyBot::App do
       klass = Class.new(SlackRubyBot::App)
       expect(klass.instance.class).to be klass
     end
+
+    it 'sets the token' do
+      token = 'slack-api-token'
+      SlackRubyBot.configure { |config| config.token = token }
+      expect(described_class.instance.token).to eq(token)
+    end
   end
 
   describe 'executable' do


### PR DESCRIPTION
Fixes #240.

I assumed that setting the config in code would take precedence over an ENV variable.

Will do a separate PR for aliases after this!