### PR TITLE
Replace no-break spaces with regular spaces during command match process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.14.1 (Next)
 
 * Your contribution here.
+* [#320](https://github.com/slack-ruby/slack-ruby-bot/pull/320): Allow command matcher to receive no-break spaces as regular spaces - [@MichaelM-Shopify](https://github.com/MichaelM-Shopify).
 * [#254](https://github.com/slack-ruby/slack-ruby-bot/pull/254): Allow setting of `config.token` and `config.aliases` in initializer - [@wasabigeek](https://github.com/wasabigeek).
 * [#253](https://github.com/slack-ruby/slack-ruby-bot/pull/253): Remove reference to unsupported Giphy content rating - [@wasabigeek](https://github.com/wasabigeek).
 

--- a/lib/slack-ruby-bot/hooks/message.rb
+++ b/lib/slack-ruby-bot/hooks/message.rb
@@ -7,7 +7,7 @@ module SlackRubyBot
         return if message_to_self_not_allowed? && message_to_self?(client, data)
         return if bot_message_not_allowed? && bot_message?(client, data)
 
-        data.text = data.text.strip if data.text
+        data.text = data.text.strip.gsub("\u00A0", ' ') if data.text
         result = child_command_classes.detect { |d| d.invoke(client, data) }
         result ||= built_in_command_classes.detect { |d| d.invoke(client, data) }
         result ||= SlackRubyBot::Commands::Unknown.tap { |d| d.invoke(client, data) }

--- a/spec/slack-ruby-bot/hooks/message_spec.rb
+++ b/spec/slack-ruby-bot/hooks/message_spec.rb
@@ -31,6 +31,20 @@ describe SlackRubyBot::Hooks::Message do
     it 'does not return unknown command class' do
       expect(built_in_command_classes).to_not include SlackRubyBot::Commands::Unknown
     end
+    it 'calls the correct command when no-break space present' do
+      client = respond_to?(:client) ? send(:client) : SlackRubyBot::Client.new
+      message_command = SlackRubyBot::Hooks::Message.new
+      allow(client).to(receive(:message)) do |options|
+        @messages ||= []
+        @messages.push(options)
+      end
+
+      run_command = message_command.call(
+        client, Hashie::Mash.new(text: "#{SlackRubyBot.config.user}\u00a0help", channel: 'channel')
+      )
+
+      expect(run_command).to(eq(SlackRubyBot::Commands::Help))
+    end
   end
   describe '#message_to_self_not_allowed?' do
     context 'with allow_message_loops set to true' do


### PR DESCRIPTION
I originally filled out an issue for this on the client library here https://github.com/slack-ruby/slack-ruby-client/issues/319 but how to fix it was more apparent to me in the bot gem. I also mainly use the slack-ruby-bot gem for my bot, so I'm not as familiar with what cases the issue might come up with on the main library.