### PR TITLE
Require Faraday >= 1.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
     - rvm: 2.6.5
       script:
         - bundle exec danger
-    - rvm: 2.3.0
+    - rvm: 2.4.0
       env: CONCURRENCY=celluloid-io
-    - rvm: 2.3.0
+    - rvm: 2.4.0
       env: CONCURRENCY=faye-websocket
-    - rvm: 2.3.0
+    - rvm: 2.4.0
       env: CONCURRENCY=async-websocket
     - rvm: 2.6.5
       env: CONCURRENCY=celluloid-io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#264](https://github.com/slack-ruby/slack-ruby-bot/pull/264): Added TOC to README - [@dblock](https://github.com/dblock).
 * [#265](https://github.com/slack-ruby/slack-ruby-bot/pull/265): Made `allow_bot_messages` and `allow_message_loops` available in `SlackRubyBot::Client` - [@dblock](https://github.com/dblock).
 * [#266](https://github.com/slack-ruby/slack-ruby-bot/pull/266): Removed deprecated `Server#hooks` - [@dblock](https://github.com/dblock).
+* [#267](https://github.com/slack-ruby/slack-ruby-bot/pull/267): Require Faraday >= 1.0 - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.15.0 (2020/5/8)

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,5 @@ if ENV.key?('CONCURRENCY')
 end
 
 group :test do
-  gem 'danger-toc', '~> 0.2.0', require: false
-  gem 'slack-ruby-danger', '~> 0.1.0', require: false
+  gem 'slack-ruby-danger', '~> 0.2.0', require: false
 end

--- a/lib/slack-ruby-bot/server.rb
+++ b/lib/slack-ruby-bot/server.rb
@@ -56,7 +56,7 @@ module SlackRubyBot
       else
         raise e
       end
-    rescue Faraday::Error::TimeoutError, Faraday::Error::ConnectionFailed, Faraday::Error::SSLError => e
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::SSLError => e
       logger.error e
       sleep 1 # ignore, try again
     rescue StandardError => e

--- a/spec/slack-ruby-bot/server_spec.rb
+++ b/spec/slack-ruby-bot/server_spec.rb
@@ -56,7 +56,7 @@ describe SlackRubyBot::Server do
         subject.run
       end.to raise_error Slack::Web::Api::Error, 'unknown'
     end
-    [Faraday::Error::ConnectionFailed, Faraday::Error::TimeoutError, Faraday::Error::SSLError].each do |err|
+    [Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError].each do |err|
       it err.to_s do
         expect(client).to receive(:start!) { raise err, 'Faraday' }
         expect(client).to receive(:start!) { raise 'unknown' }


### PR DESCRIPTION
This is required by slack-ruby-client now, so don't add it to .gemspec. But rescuing these exceptions now works.