### PR TITLE
Added active-support dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.16.1 (Next)
 
+* [#271](https://github.com/slack-ruby/slack-ruby-bot/pull/271): Added explicit dependency on `activesupport` - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.16.0 (2020/7/26)

--- a/slack-ruby-bot.gemspec
+++ b/slack-ruby-bot.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'The easiest way to write a Slack bot in Ruby.'
   s.required_ruby_version = '>= 2.3'
+  s.add_dependency 'activesupport'
   s.add_dependency 'hashie'
   s.add_dependency 'slack-ruby-client', '>= 0.14.0'
   s.add_development_dependency 'rack-test'


### PR DESCRIPTION
We removed a dependency on activesupport in https://github.com/slack-ruby/slack-ruby-client/pull/325, but it's needed by the command classes in this library. 

Closes https://github.com/slack-ruby/slack-ruby-bot/issues/270